### PR TITLE
[SDK-2424] Add metadata discovery

### DIFF
--- a/packages/access-token-jwt/package.json
+++ b/packages/access-token-jwt/package.json
@@ -34,7 +34,10 @@
   "jest": {
     "preset": "ts-jest",
     "resolver": "./resolver.js",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "src/*"
+    ]
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/access-token-jwt/src/discovery.ts
+++ b/packages/access-token-jwt/src/discovery.ts
@@ -1,0 +1,49 @@
+import { URL } from 'url';
+import fetch from './fetch';
+import { AggregateError } from './errors';
+
+const OIDC_DISCOVERY = '/.well-known/openid-configuration';
+const OAUTH2_DISCOVERY = '/.well-known/oauth-authorization-server';
+
+export interface IssuerMetadata {
+  issuer: string;
+  jwks_uri: string;
+  [key: string]: unknown;
+}
+
+const discover = async (uri: string): Promise<IssuerMetadata> => {
+  const url = new URL(uri);
+
+  if (url.pathname.includes('/.well-known/')) {
+    return fetch<IssuerMetadata>(url);
+  }
+
+  const pathnames = [];
+  if (url.pathname.endsWith('/')) {
+    pathnames.push(`${url.pathname}${OIDC_DISCOVERY.substring(1)}`);
+  } else {
+    pathnames.push(`${url.pathname}${OIDC_DISCOVERY}`);
+  }
+  if (url.pathname === '/') {
+    pathnames.push(`${OAUTH2_DISCOVERY}`);
+  } else {
+    pathnames.push(`${OAUTH2_DISCOVERY}${url.pathname}`);
+  }
+
+  const errors = [];
+  for (const pathname of pathnames) {
+    try {
+      const wellKnownUri = new URL(pathname, url);
+      return await fetch<IssuerMetadata>(wellKnownUri);
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+
+  throw new AggregateError(
+    errors,
+    errors.map(({ message }) => message).join('\n')
+  );
+};
+
+export default discover;

--- a/packages/access-token-jwt/src/errors.ts
+++ b/packages/access-token-jwt/src/errors.ts
@@ -1,0 +1,24 @@
+export class FetchError extends Error {
+  constructor(
+    public url: string,
+    public statusCode?: number,
+    public statusMessage?: string
+  ) {
+    super(`Failed to fetch ${url}, responded with ${statusCode}`);
+    this.name = this.constructor.name;
+  }
+}
+
+export class JsonParseError extends Error {
+  constructor(public url: string) {
+    super(`Failed to parse the response from ${url}`);
+    this.name = this.constructor.name;
+  }
+}
+
+export class AggregateError extends Error {
+  constructor(public errors: Error[], message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/packages/access-token-jwt/src/fetch.ts
+++ b/packages/access-token-jwt/src/fetch.ts
@@ -1,0 +1,49 @@
+import { URL } from 'url';
+import { get as getHttp } from 'http';
+import { get as getHttps } from 'https';
+import { once } from 'events';
+import type { ClientRequest, IncomingMessage } from 'http';
+import { FetchError, JsonParseError } from './errors';
+
+const decoder = new TextDecoder();
+
+const concat = (...buffers: Uint8Array[]): Uint8Array => {
+  const size = buffers.reduce((acc, { length }) => acc + length, 0);
+  const buf = new Uint8Array(size);
+  let i = 0;
+  buffers.forEach((buffer) => {
+    buf.set(buffer, i);
+    i += buffer.length;
+  });
+  return buf;
+};
+
+const protocols: {
+  [protocol: string]: (...args: Parameters<typeof getHttps>) => ClientRequest;
+} = {
+  'https:': getHttps,
+  'http:': getHttp,
+};
+
+const fetch = async <TResponse>(url: URL): Promise<TResponse> => {
+  const req = protocols[url.protocol](url.href, {});
+
+  const [response] = <[IncomingMessage]>await once(req, 'response');
+
+  if (response.statusCode !== 200) {
+    throw new FetchError(url.href, response.statusCode, response.statusMessage);
+  }
+
+  const parts = [];
+  for await (const part of response) {
+    parts.push(part);
+  }
+
+  try {
+    return JSON.parse(decoder.decode(concat(...parts)));
+  } catch (err) {
+    throw new JsonParseError(url.href);
+  }
+};
+
+export default fetch;

--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -1,1 +1,7 @@
-export { default as tokenVerifier } from './token-verifier';
+export {
+  default as tokenVerifier,
+  TokenVerifierOptions,
+  VerifyJwt,
+} from './token-verifier';
+export * from './errors';
+export { default as discover, IssuerMetadata } from './discovery';

--- a/packages/access-token-jwt/test/discovery.test.ts
+++ b/packages/access-token-jwt/test/discovery.test.ts
@@ -1,0 +1,194 @@
+import nock = require('nock');
+import { discover, AggregateError, FetchError, JsonParseError } from '../src';
+
+const success = { issuer: 'https://op.example.com' };
+
+describe('discover', () => {
+  afterEach(nock.cleanAll);
+
+  it('gets discovery metadata for custom /.well-known', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/example-configuration')
+      .reply(200, success);
+
+    await expect(
+      discover('https://op.example.com/.well-known/example-configuration')
+    ).resolves.toMatchObject(success);
+  });
+
+  it('gets discovery metadata for openid-configuration', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, success);
+
+    await expect(
+      discover('https://op.example.com/.well-known/openid-configuration')
+    ).resolves.toMatchObject(success);
+  });
+
+  it('gets discovery metadata for openid-configuration with base url', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, success);
+
+    await expect(discover('https://op.example.com')).resolves.toMatchObject(
+      success
+    );
+  });
+
+  it('gets discovery metadata for openid-configuration with path (with trailing slash)', async () => {
+    nock('https://op.example.com')
+      .get('/oidc/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: 'https://op.example.com/oidc',
+      });
+
+    await expect(
+      discover('https://op.example.com/oidc/')
+    ).resolves.toMatchObject({
+      issuer: 'https://op.example.com/oidc',
+    });
+  });
+
+  it('gets discovery metadata for openid-configuration with path (without trailing slash)', async () => {
+    nock('https://op.example.com')
+      .get('/oidc/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: 'https://op.example.com/oidc',
+      });
+
+    await expect(
+      discover('https://op.example.com/oidc')
+    ).resolves.toMatchObject({
+      issuer: 'https://op.example.com/oidc',
+    });
+  });
+
+  it('gets discovery metadata for openid-configuration with path and query', async () => {
+    nock('https://op.example.com')
+      .get('/oidc/.well-known/openid-configuration')
+      .query({ foo: 'bar' })
+      .reply(200, {
+        issuer: 'https://op.example.com/oidc',
+      });
+
+    await expect(
+      discover(
+        'https://op.example.com/oidc/.well-known/openid-configuration?foo=bar'
+      )
+    ).resolves.toMatchObject({
+      issuer: 'https://op.example.com/oidc',
+    });
+  });
+
+  it('gets discovery metadata for oauth-authorization-server', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/oauth-authorization-server')
+      .reply(200, success);
+
+    await expect(
+      discover('https://op.example.com/.well-known/oauth-authorization-server')
+    ).resolves.toMatchObject(success);
+  });
+
+  it('gets discovery metadata for oauth-authorization-server with base url', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/oauth-authorization-server')
+      .reply(200, success);
+
+    await expect(discover('https://op.example.com')).resolves.toMatchObject(
+      success
+    );
+  });
+
+  it('gets discovery metadata for oauth-authorization-server with path (with trailing slash)', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/oauth-authorization-server/oauth2/')
+      .reply(200, success);
+
+    await expect(
+      discover('https://op.example.com/oauth2/')
+    ).resolves.toMatchObject(success);
+  });
+
+  it('gets discovery metadata for oauth-authorization-server with path (without trailing slash)', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/oauth-authorization-server/oauth2')
+      .reply(200, success);
+
+    await expect(
+      discover('https://op.example.com/oauth2')
+    ).resolves.toMatchObject(success);
+  });
+
+  it('gets discovery metadata for oauth-authorization-server with path and query', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/oauth-authorization-server/oauth2')
+      .query({ foo: 'bar' })
+      .reply(200, success);
+
+    await expect(
+      discover(
+        'https://op.example.com/.well-known/oauth-authorization-server/oauth2?foo=bar'
+      )
+    ).resolves.toMatchObject(success);
+  });
+
+  it('is rejected when both Metadata endpoints fail', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/openid-configuration')
+      .reply(500)
+      .get('/.well-known/oauth-authorization-server')
+      .reply(200, '');
+
+    try {
+      await discover('https://op.example.com');
+      fail('discover should fail');
+    } catch (e) {
+      expect(e).toBeInstanceOf(AggregateError);
+      expect(e).toHaveProperty(
+        'message',
+        'Failed to fetch https://op.example.com/.well-known/openid-configuration, responded with 500\n' +
+          'Failed to parse the response from https://op.example.com/.well-known/oauth-authorization-server'
+      );
+      expect(e.errors).toContainEqual(
+        expect.objectContaining({
+          name: 'FetchError',
+          url: 'https://op.example.com/.well-known/openid-configuration',
+          statusCode: 500,
+        })
+      );
+      expect(e.errors).toContainEqual(
+        expect.objectContaining({
+          name: 'JsonParseError',
+        })
+      );
+    }
+  });
+
+  it('is rejected .well-known Metadata endpoint fails', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/example-configuration')
+      .reply(500);
+
+    await expect(
+      discover('https://op.example.com/.well-known/example-configuration')
+    ).rejects.toThrowError(FetchError);
+  });
+
+  it('is rejected .well-known Metadata endpoint responds with non JSON response', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/example-configuration')
+      .reply(200, '');
+
+    await expect(
+      discover('https://op.example.com/.well-known/example-configuration')
+    ).rejects.toThrowError(JsonParseError);
+  });
+
+  it('is rejected with Error when no absolute URL is provided', async () => {
+    await expect(
+      discover('op.example.com/.well-known/foobar')
+    ).rejects.toThrowError('Invalid URL: op.example.com/.well-known/foobar');
+  });
+});

--- a/packages/access-token-jwt/test/helpers.ts
+++ b/packages/access-token-jwt/test/helpers.ts
@@ -1,0 +1,48 @@
+import SignJWT from 'jose/jwt/sign';
+import { generateKeyPair } from 'jose/util/generate_key_pair';
+import { fromKeyLike } from 'jose/jwk/from_key_like';
+import nock = require('nock');
+
+export const now = (Date.now() / 1000) | 0;
+const day = 60 * 60 * 24;
+
+interface CreateJWTOptions {
+  payload?: { [key: string]: any };
+  issuer?: string;
+  subject?: string;
+  audience?: string;
+  jwksUri?: string;
+  kid?: string;
+  iat?: number;
+  exp?: number;
+}
+
+export const createJwt = async ({
+  payload = {},
+  issuer = 'https://issuer.example.com/',
+  subject = 'me',
+  audience = 'https://api/',
+  jwksUri = '/.well-known/jwks.json',
+  iat = now,
+  exp = now + day,
+  kid = 'kid',
+}: CreateJWTOptions = {}): Promise<string> => {
+  const { publicKey, privateKey } = await generateKeyPair('RS256');
+  const publicJwk = await fromKeyLike(publicKey);
+  nock(issuer)
+    .get(jwksUri)
+    .reply(200, { keys: [{ kid: 'kid', ...publicJwk }] });
+
+  return new SignJWT(payload)
+    .setProtectedHeader({
+      alg: 'RS256',
+      typ: 'JWT',
+      kid,
+    })
+    .setIssuer(issuer)
+    .setSubject(subject)
+    .setAudience(audience)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+};

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -1,0 +1,34 @@
+import nock = require('nock');
+import discovery from '../src/discovery';
+import { createJwt } from './helpers';
+import { tokenVerifier } from '../src';
+
+describe('index', () => {
+  afterEach(nock.cleanAll);
+
+  it('gets metatdata and verifies jwt', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/openid-configuration')
+      .reply(200, {
+        issuer: 'https://op.example.com',
+        jwks_uri: 'https://op.example.com/.well-known/jwks.json',
+      });
+    const jwt = await createJwt({ issuer: 'https://op.example.com' });
+
+    const { issuer, jwks_uri: jwksUri } = await discovery(
+      'https://op.example.com'
+    );
+    const verify = tokenVerifier({
+      jwksUri,
+      issuer,
+      audience: 'https://api/',
+    });
+    await expect(verify(jwt)).resolves.toMatchObject({
+      iss: 'https://op.example.com',
+      sub: 'me',
+      aud: 'https://api/',
+      iat: expect.any(Number),
+      exp: expect.any(Number),
+    });
+  });
+});

--- a/packages/access-token-jwt/test/token-verifier.test.ts
+++ b/packages/access-token-jwt/test/token-verifier.test.ts
@@ -1,53 +1,10 @@
-import SignJWT from 'jose/jwt/sign';
-import { generateKeyPair } from 'jose/util/generate_key_pair';
-import { fromKeyLike } from 'jose/jwk/from_key_like';
 import nock = require('nock');
+import { createJwt, now } from './helpers';
 import { tokenVerifier } from '../src';
 
-const now = (Date.now() / 1000) | 0;
-const day = 60 * 60 * 24;
-
-interface CreateJWTOptions {
-  payload?: { [key: string]: any };
-  issuer?: string;
-  subject?: string;
-  audience?: string;
-  kid?: string;
-  iat?: number;
-  exp?: number;
-}
-
-const createJwt = async ({
-  payload = {},
-  issuer = 'https://issuer.example.com/',
-  subject = 'me',
-  audience = 'https://api/',
-  iat = now,
-  exp = now + day,
-  kid = 'kid',
-}: CreateJWTOptions = {}): Promise<string> => {
-  const { publicKey, privateKey } = await generateKeyPair('RS256');
-  const publicJwk = await fromKeyLike(publicKey);
-  nock(issuer)
-    .get('/.well-known/jwks.json')
-    .once()
-    .reply(200, { keys: [{ kid: 'kid', ...publicJwk }] });
-
-  return new SignJWT(payload)
-    .setProtectedHeader({
-      alg: 'RS256',
-      typ: 'JWT',
-      kid,
-    })
-    .setIssuer(issuer)
-    .setSubject(subject)
-    .setAudience(audience)
-    .setIssuedAt(iat)
-    .setExpirationTime(exp)
-    .sign(privateKey);
-};
-
 describe('token-verifier', () => {
+  afterEach(nock.cleanAll);
+
   it('should verify the token', async () => {
     const jwt = await createJwt();
 


### PR DESCRIPTION
### Description

Add fetch (borrowed from [panva/jose](https://github.com/panva/jose/tree/main/src/runtime/node)) and metadata discovery (borrowed from [panva/openid-client](https://github.com/panva/node-openid-client/blob/main/lib/issuer.js#L210))

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`
