### PR TITLE
[SDK-2602] Fix formatting on error_description attribute

### DIFF
--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -142,23 +142,4 @@ describe('index', () => {
     const promise = verify(jwt);
     await expect(promise).rejects.toThrow(`Unexpected 'foo' value`);
   });
-
-  it('should accept custom validators', async () => {
-    const jwt = await createJwt({
-      issuer: 'https://op.example.com',
-      payload: { foo: 'baz' },
-    });
-
-    const verify = jwtVerifier({
-      issuerBaseURL: 'https://op.example.com',
-      audience: 'https://api/',
-      agent: new Agent(),
-      timeoutDuration: 1000,
-      validators: {
-        foo: 'bar',
-      },
-    });
-    const promise = verify(jwt);
-    await expect(promise).rejects.toThrow(`Unexpected 'foo' value`);
-  });
 });

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -142,4 +142,23 @@ describe('index', () => {
     const promise = verify(jwt);
     await expect(promise).rejects.toThrow(`Unexpected 'foo' value`);
   });
+
+  it('should accept custom validators', async () => {
+    const jwt = await createJwt({
+      issuer: 'https://op.example.com',
+      payload: { foo: 'baz' },
+    });
+
+    const verify = jwtVerifier({
+      issuerBaseURL: 'https://op.example.com',
+      audience: 'https://api/',
+      agent: new Agent(),
+      timeoutDuration: 1000,
+      validators: {
+        foo: 'bar',
+      },
+    });
+    const promise = verify(jwt);
+    await expect(promise).rejects.toThrow(`Unexpected 'foo' value`);
+  });
 });

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -356,7 +356,7 @@ describe('index', () => {
     );
   });
 
-  it('should escape errors with quotes', async () => {
+  it('should replace double quotes in header with single quotes', async () => {
     const jwt = await createJwt({ payload: { nbf: false } });
     const baseUrl = await setup();
     await expectFailsWith(
@@ -368,7 +368,7 @@ describe('index', () => {
       }),
       401,
       'invalid_token',
-      '\\"nbf\\" claim must be a number'
+      "'nbf' claim must be a number"
     );
   });
 });

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -355,4 +355,20 @@ describe('index', () => {
       })
     );
   });
+
+  it('should escape errors with quotes', async () => {
+    const jwt = await createJwt({ payload: { nbf: false } });
+    const baseUrl = await setup();
+    await expectFailsWith(
+      got(baseUrl, {
+        headers: {
+          authorization: `Bearer ${jwt}`,
+        },
+        responseType: 'json',
+      }),
+      401,
+      'invalid_token',
+      '\\"nbf\\" claim must be a number'
+    );
+  });
 });

--- a/packages/oauth2-bearer/src/errors.ts
+++ b/packages/oauth2-bearer/src/errors.ts
@@ -67,7 +67,7 @@ export class InsufficientScopeError extends UnauthorizedError {
 
 // Generate a response header per https://tools.ietf.org/html/rfc6750#section-3
 const getHeaders = (error: string, description: string, scopes?: string[]) => ({
-  'WWW-Authenticate': `Bearer realm="api", error="${error}", error_description="${description}"${
-    (scopes && `, scope="${scopes.join(' ')}"`) || ''
-  }`,
+  'WWW-Authenticate': `Bearer realm="api", error="${error}", error_description=${JSON.stringify(
+    description
+  )}${(scopes && `, scope="${scopes.join(' ')}"`) || ''}`,
 });

--- a/packages/oauth2-bearer/src/errors.ts
+++ b/packages/oauth2-bearer/src/errors.ts
@@ -67,7 +67,8 @@ export class InsufficientScopeError extends UnauthorizedError {
 
 // Generate a response header per https://tools.ietf.org/html/rfc6750#section-3
 const getHeaders = (error: string, description: string, scopes?: string[]) => ({
-  'WWW-Authenticate': `Bearer realm="api", error="${error}", error_description=${JSON.stringify(
-    description
-  )}${(scopes && `, scope="${scopes.join(' ')}"`) || ''}`,
+  'WWW-Authenticate': `Bearer realm="api", error="${error}", error_description="${description.replace(
+    /"/g,
+    "'"
+  )}"${(scopes && `, scope="${scopes.join(' ')}"`) || ''}`,
 });

--- a/packages/oauth2-bearer/test/errors.test.ts
+++ b/packages/oauth2-bearer/test/errors.test.ts
@@ -46,6 +46,19 @@ describe('errors', () => {
     });
   });
 
+  it('should avoid nested double quotes in header', () => {
+    expect(new InvalidRequestError('expected "foo" got "bar"')).toMatchObject({
+      code: 'invalid_request',
+      headers: {
+        'WWW-Authenticate': `Bearer realm="api", error="invalid_request", error_description="expected 'foo' got 'bar'"`,
+      },
+      message: 'expected "foo" got "bar"',
+      name: 'InvalidRequestError',
+      status: 400,
+      statusCode: 400,
+    });
+  });
+
   it('should raise an Invalid Token error', () => {
     expect(new InvalidTokenError()).toMatchObject({
       code: 'invalid_token',


### PR DESCRIPTION
### Description

Errors that contain double quotes would lead to invalid `WWW-Authenticate` header values in the `error_description` attribute, eg `error_description="Unexpected "foo" value"`, replace `"` with `'` to make valid headers eg `error_description="Unexpected 'foo' value"`

### References

https://datatracker.ietf.org/doc/html/rfc6750#section-3

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
