### PR TITLE
[SDK-2631] Add support for Access Tokens signed with a symmetric secret

### DIFF
--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -1,4 +1,6 @@
 import { strict as assert } from 'assert';
+import { Buffer } from 'buffer';
+import { createSecretKey } from 'crypto';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { URL } from 'url';
@@ -38,7 +40,7 @@ export interface JwtVerifierOptions {
 
   /**
    * Url for the authorization server's JWKS to find the public key to verify
-   * an Access Token JWT.
+   * an Access Token JWT signed with an asymmetric algorithm.
    * REQUIRED (if you don't include {@Link AuthOptions.issuerBaseURL})
    * You can also provide the `JWKS_URI` environment variable.
    */
@@ -106,6 +108,21 @@ export interface JwtVerifierOptions {
    * Defaults to false.
    */
   strict?: boolean;
+
+  /**
+   * Secret to verify an Access Token JWT signed with a symmetric algorithm.
+   * By default this SDK validates tokens signed with asymmetric algorithms.
+   */
+  secret?: string;
+
+  /**
+   * You must provide this if your tokens are signed with symmetric algorithms
+   * and it must be one of HS256, HS384 or HS512.
+   * You may provide this if your tokens are signed with asymmetric algorithms
+   * and, if provided, it must be one of RS256, RS384, RS512, PS256, PS384,
+   * PS512, ES256, ES256K, ES384, ES512 or EdDSA (case-sensitive).
+   */
+  tokenSigningAlg?: string;
 }
 
 export interface VerifyJwtResult {
@@ -127,11 +144,28 @@ export type VerifyJwt = (jwt: string) => Promise<VerifyJwtResult>;
 
 type GetKeyFn = ReturnType<typeof createRemoteJWKSet>;
 
+const ASYMMETRIC_ALGS = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES256K',
+  'ES384',
+  'ES512',
+  'EdDSA',
+];
+const SYMMETRIC_ALGS = ['HS256', 'HS384', 'HS512'];
+
 const jwtVerifier = ({
   issuerBaseURL = process.env.ISSUER_BASE_URL as string,
   jwksUri = process.env.JWKS_URI as string,
   issuer = process.env.ISSUER as string,
   audience = process.env.AUDIENCE as string,
+  secret = process.env.SECRET as string,
+  tokenSigningAlg = process.env.TOKEN_SIGNING_ALG as string,
   agent,
   cooldownDuration = 30000,
   timeoutDuration = 5000,
@@ -146,11 +180,32 @@ const jwtVerifier = ({
   let allowedSigningAlgs: string[] | undefined;
 
   assert(
-    (issuerBaseURL && !(issuer || jwksUri)) ||
-      (!issuerBaseURL && issuer && jwksUri),
-    "You must provide an 'issuerBaseURL' or an 'issuer' and 'jwksUri'"
+    issuerBaseURL || (issuer && jwksUri) || (issuer && secret),
+    "You must provide an 'issuerBaseURL', an 'issuer' and 'jwksUri' or an 'issuer' and 'secret'"
+  );
+  assert(
+    !(secret && jwksUri),
+    "You must not provide both a 'secret' and 'jwksUri'"
   );
   assert(audience, "An 'audience' is required to validate the 'aud' claim");
+  assert(
+    !secret || (secret && tokenSigningAlg),
+    "You must provide a 'tokenSigningAlg' for validating symmetric algorithms"
+  );
+  assert(
+    secret || !tokenSigningAlg || ASYMMETRIC_ALGS.includes(tokenSigningAlg),
+    `You must supply one of ${ASYMMETRIC_ALGS.join(
+      ', '
+    )} for 'tokenSigningAlg' to validate asymmetrically signed tokens`
+  );
+  assert(
+    !secret || (tokenSigningAlg && SYMMETRIC_ALGS.includes(tokenSigningAlg)),
+    `You must supply one of ${SYMMETRIC_ALGS.join(
+      ', '
+    )} for 'tokenSigningAlg' to validate symmetrically signed tokens`
+  );
+
+  const secretKey = secret && createSecretKey(Buffer.from(secret));
 
   const JWKS = async (...args: Parameters<GetKeyFn>) => {
     if (!origJWKS) {
@@ -165,7 +220,7 @@ const jwtVerifier = ({
 
   return async (jwt: string) => {
     try {
-      if (!jwksUri) {
+      if (issuerBaseURL) {
         discovery =
           discovery || discover(issuerBaseURL, { agent, timeoutDuration });
         ({
@@ -181,11 +236,15 @@ const jwtVerifier = ({
           clockTolerance,
           maxTokenAge,
           strict,
-          allowedSigningAlgs
+          allowedSigningAlgs,
+          tokenSigningAlg
         ),
         ...customValidators,
       };
-      const { payload, protectedHeader: header } = await jwtVerify(jwt, JWKS);
+      const { payload, protectedHeader: header } = await jwtVerify(
+        jwt,
+        secretKey || JWKS
+      );
       await validate(payload, header, validators);
       return { payload, header, token: jwt };
     } catch (e) {

--- a/packages/access-token-jwt/src/validate.ts
+++ b/packages/access-token-jwt/src/validate.ts
@@ -62,12 +62,14 @@ export const defaultValidators = (
   clockTolerance: number,
   maxTokenAge: number | undefined,
   strict: boolean,
-  allowedSigningAlgs: string[] | undefined
+  allowedSigningAlgs: string[] | undefined,
+  tokenSigningAlg: string | undefined
 ): Validators => ({
   alg: (alg) =>
     typeof alg === 'string' &&
     alg.toLowerCase() !== 'none' &&
-    (!allowedSigningAlgs || allowedSigningAlgs.includes(alg)),
+    (!allowedSigningAlgs || allowedSigningAlgs.includes(alg)) &&
+    (!tokenSigningAlg || alg === tokenSigningAlg),
   typ: (typ) =>
     !strict ||
     (typeof typ === 'string' &&

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { Agent } from 'http';
 import nock = require('nock');
 import sinon = require('sinon');
@@ -29,6 +30,28 @@ describe('index', () => {
     const verify = jwtVerifier({
       issuer: 'https://op.example.com',
       jwksUri: 'https://op.example.com/.well-known/jwks.json',
+      audience: 'https://api/',
+    });
+    await expect(verify(jwt)).resolves.toHaveProperty('payload', {
+      iss: 'https://op.example.com',
+      sub: 'me',
+      aud: 'https://api/',
+      iat: expect.any(Number),
+      exp: expect.any(Number),
+    });
+  });
+
+  it('verifies jwt signed with symmetric secret', async () => {
+    const secret = randomBytes(32).toString('hex');
+    const jwt = await createJwt({
+      issuer: 'https://op.example.com',
+      secret,
+    });
+
+    const verify = jwtVerifier({
+      issuer: 'https://op.example.com',
+      secret,
+      tokenSigningAlg: 'HS256',
       audience: 'https://api/',
     });
     await expect(verify(jwt)).resolves.toHaveProperty('payload', {

--- a/packages/access-token-jwt/test/validate.test.ts
+++ b/packages/access-token-jwt/test/validate.test.ts
@@ -22,6 +22,7 @@ const validators = ({
   maxTokenAge = 10,
   strict = false,
   allowedSigningAlgs,
+  tokenSigningAlg,
 }: {
   issuer?: string;
   audience?: string | string[];
@@ -29,6 +30,7 @@ const validators = ({
   maxTokenAge?: number;
   strict?: boolean;
   allowedSigningAlgs?: string[];
+  tokenSigningAlg?: string;
 } = {}) =>
   defaultValidators(
     issuer,
@@ -36,7 +38,8 @@ const validators = ({
     clockTolerance,
     maxTokenAge,
     strict,
-    allowedSigningAlgs
+    allowedSigningAlgs,
+    tokenSigningAlg
   );
 
 describe('validate', () => {

--- a/packages/examples/express-api.ts
+++ b/packages/examples/express-api.ts
@@ -7,6 +7,7 @@ import {
 import express = require('express');
 import cors = require('cors');
 import { Handler } from 'express';
+import secret from './secret';
 
 const app = express();
 const issuerBaseURL = 'http://localhost:3000';
@@ -44,5 +45,11 @@ app.get(
 );
 
 app.get('/strict', auth({ issuerBaseURL, audience, strict: true }), handler);
+
+app.get(
+  '/symmetric',
+  auth({ secret, issuer: issuerBaseURL, audience, tokenSigningAlg: 'HS256' }),
+  handler
+);
 
 export default app;

--- a/packages/examples/playground.ejs
+++ b/packages/examples/playground.ejs
@@ -69,7 +69,6 @@
     <script type="module">
       import { SignJWT } from 'https://cdn.jsdelivr.net/npm/jose@latest/dist/browser/jwt/sign.js';
       import { parseJwk } from 'https://cdn.jsdelivr.net/npm/jose@latest/dist/browser/jwk/parse.js';
-      window.SignJWT = SignJWT;
 
       const result = document.querySelector('#result');
       const header = document.querySelector('#header');

--- a/packages/examples/playground.ejs
+++ b/packages/examples/playground.ejs
@@ -53,11 +53,15 @@
           <button onclick="request(3001, '/claim-includes')">claimIncludes('foo', 'bar', 'baz')</button>
           <button onclick="request(3001, '/custom')">auth({ validators: { iss: false } })</button>
           <button onclick="request(3001, '/strict')">auth({ strict: true })</button>
+          <button onclick="request(3001, '/symmetric')">auth({ secret: '...' })</button>
         </fieldset>
         <h3>Log:</h3>
         <div id="result"></div>
         <textarea id="privateJwk" style="display: none;">
           <%= JSON.stringify(privateJwk, null, 2) %>
+        </textarea>
+        <textarea id="secret" style="display: none;">
+          <%= secret %>
         </textarea>
       </div>
     </div>
@@ -65,12 +69,14 @@
     <script type="module">
       import { SignJWT } from 'https://cdn.jsdelivr.net/npm/jose@latest/dist/browser/jwt/sign.js';
       import { parseJwk } from 'https://cdn.jsdelivr.net/npm/jose@latest/dist/browser/jwk/parse.js';
+      window.SignJWT = SignJWT;
 
       const result = document.querySelector('#result');
       const header = document.querySelector('#header');
       const payload = document.querySelector('#payload');
       const at = document.querySelector('#at');
       const privateJwk = document.querySelector('#privateJwk');
+      const secret = document.querySelector('#secret');
 
       const log = (msg) => {
         const item = document.createElement('p');
@@ -80,10 +86,12 @@
 
       window.makeAccessToken = async () => {
         const privateKey = await parseJwk(JSON.parse(privateJwk.value), 'RS256');
+        const symmetricSecret = (new TextEncoder()).encode(secret.value.trim());
         try {
+          const head = JSON.parse(header.value);
           at.value = await new SignJWT(JSON.parse(payload.value))
-            .setProtectedHeader(JSON.parse(header.value))
-            .sign(privateKey);
+            .setProtectedHeader(head)
+            .sign(head.alg.startsWith('HS') ? symmetricSecret : privateKey);
         } catch (e) {
           at.value = '';
           console.error(e);

--- a/packages/examples/playground.ts
+++ b/packages/examples/playground.ts
@@ -1,6 +1,7 @@
 import express = require('express');
 import { generateKeyPair } from 'jose/util/generate_key_pair';
 import { fromKeyLike, JWK } from 'jose/jwk/from_key_like';
+import secret from './secret';
 
 const app = express();
 
@@ -27,6 +28,7 @@ app.get('/', async (req, res, next) => {
   const { privateJwk } = await keys();
   res.render('playground.ejs', {
     privateJwk,
+    secret,
     issuer,
     audience,
   });

--- a/packages/examples/secret.ts
+++ b/packages/examples/secret.ts
@@ -1,0 +1,3 @@
+import { randomBytes } from 'crypto';
+
+export default randomBytes(32).toString('hex');

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -35,7 +35,7 @@ npm install express-oauth2-jwt-bearer
 The library requires [issuerBaseURL](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authoptions.html#issuerbaseurl) and [audience](http://localhost:8000/docs/interfaces/authoptions.html#audience), which can be configured with environmental variables:
 
 ```shell
-ISSUER_BASE_URL=https://YOUR_DOMAIN
+ISSUER_BASE_URL=https://YOUR_ISSUER_DOMAIN
 AUDIENCE=https://my-api.com
 ```
 
@@ -50,8 +50,22 @@ app.use(auth());
 const { auth } = require('express-oauth2-jwt-bearer');
 app.use(
     auth({
-      issuerBaseURL: 'https://YOUR_DOMAIN',
+      issuerBaseURL: 'https://YOUR_ISSUER_DOMAIN',
       audience: 'https://my-api.com'
+    })
+);
+```
+
+... or for JWTs signed with symmetric algorithms (eg `HS256`)
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+app.use(
+    auth({
+      issuer: 'https://YOUR_ISSUER_DOMAIN',
+      audience: 'https://my-api.com',
+      secret: 'YOUR SECRET',
+      tokenSigningAlg: 'HS256'
     })
 );
 ```


### PR DESCRIPTION
### Description

Adding support for Access Tokens signed with a symmetric secret (eg a `clientSecret` in Auth0)

To enable this:

```js
const { auth } = require('express-oauth2-jwt-bearer');

app.use(
    auth({
      issuer: 'https://YOUR_ISSUER_DOMAIN',
      audience: 'https://my-api.com',
      secret: 'YOUR SECRET (eg Client Secret)',
      tokenSigningAlg: 'HS256' // Required for symmetric secrets and must be one of HS256, HS384, or HS512
    })
);
```

You can also use the `SECRET` and `TOKEN_SIGNING_ALG` env vars.

### References

https://github.com/auth0/express-oauth2-bearer#api-documentation
https://auth0.com/docs/tokens/signing-algorithms

### Testing

- Run the playground app with `npm run dev --workspace=packages/examples`
- Go to `https://localhost:3000`
- Change the `header.alg` field to `HS256`
- Push the `auth({ secret: '...' })` button

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
