### PR TITLE
[express-oauth2-jwt-bearer] Use the new release automation solution

### DIFF
--- a/packages/express-oauth2-jwt-bearer/.shiprc
+++ b/packages/express-oauth2-jwt-bearer/.shiprc
@@ -1,0 +1,3 @@
+{
+    "postbump": "npm install --prefix=../.. && npm run docs --prefix=../.."
+}


### PR DESCRIPTION
### Description

This PR adds support for the new release automation CLI.
The CLI needs to be run from the `packages/express-oauth2-jwt-bearer` dir.

<img width="1365" alt="Screen Shot 2021-09-07 at 23 43 25" src="https://user-images.githubusercontent.com/5055789/132438026-8c887b8b-82bd-4819-9988-e8a1699d77af.png">

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
