### PR TITLE
Update Orb version to fix custom publish command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.3.0
+  ship: auth0/ship@0.3.1
 jobs:
   test:
     executor:


### PR DESCRIPTION
This is a fixup for PR #24 

This line will not run correctly on versions < 0.3.1 of the orb. 

https://github.com/auth0/node-oauth2-jwt-bearer/pull/24/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R22