### PR TITLE
[SDK-2827] Update some error status codes and descriptions

### DIFF
--- a/packages/access-token-jwt/src/claim-check.ts
+++ b/packages/access-token-jwt/src/claim-check.ts
@@ -25,7 +25,7 @@ const isClaimIncluded = (
   expected: JSONPrimitive[]
 ): ((payload: JWTPayload) => boolean) => (payload) => {
   if (!(claim in payload)) {
-    return false;
+    throw new InvalidTokenError(`Missing '${claim}' claim`);
   }
 
   let actual = payload[claim];
@@ -87,7 +87,7 @@ export const claimEquals: ClaimEquals = (claim, expected) => {
 
   return claimCheck((payload) => {
     if (!(claim in payload)) {
-      return false;
+      throw new InvalidTokenError(`Missing '${claim}' claim`);
     }
     return payload[claim] === expected;
   }, `Unexpected '${claim}' value`);

--- a/packages/access-token-jwt/test/claim-check.test.ts
+++ b/packages/access-token-jwt/test/claim-check.test.ts
@@ -56,7 +56,7 @@ describe('claim-check', () => {
 
     it('should throw if claim not in payload', () => {
       expect(claimEquals('foo', 'bar').bind(null, {})).toThrowError(
-        "Unexpected 'foo' value"
+        "Missing 'foo' claim"
       );
     });
 
@@ -80,7 +80,7 @@ describe('claim-check', () => {
 
     it('should throw if claim not in payload', () => {
       expect(claimIncludes('foo', 'bar').bind(null, {})).toThrowError(
-        "Unexpected 'foo' value"
+        "Missing 'foo' claim"
       );
     });
 

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -18,17 +18,21 @@ import {
 const expectFailsWith = async (
   promise: CancelableRequest,
   status: number,
-  code: string,
-  description: string,
+  code?: string,
+  description?: string,
   scopes?: string
 ) => {
   try {
     await promise;
     fail('Request should fail');
   } catch (e) {
+    const error = code ? `, error="${code}"` : '';
+    const errorDescription = description
+      ? `, error_description="${description}"`
+      : '';
     expect(e.response.statusCode).toBe(status);
     expect(e.response.headers['www-authenticate']).toBe(
-      `Bearer realm="api", error="${code}", error_description="${description}"${
+      `Bearer realm="api"${error}${errorDescription}${
         (scopes && ', scope="' + scopes + '"') || ''
       }`
     );
@@ -82,12 +86,7 @@ describe('index', () => {
 
   it('should fail for anonymous requests', async () => {
     const baseUrl = await setup();
-    await expectFailsWith(
-      got(baseUrl),
-      400,
-      'invalid_request',
-      'Bearer token is missing'
-    );
+    await expectFailsWith(got(baseUrl), 401);
   });
 
   it('should accept empty arguments and env vars', async () => {

--- a/packages/oauth2-bearer/src/get-token.ts
+++ b/packages/oauth2-bearer/src/get-token.ts
@@ -1,7 +1,7 @@
 /**
  * Get a Bearer Token from a request per https://tools.ietf.org/html/rfc6750#section-2
  */
-import { InvalidRequestError } from './errors';
+import { InvalidRequestError, UnauthorizedError } from './errors';
 
 type QueryLike = Record<string, unknown> & { access_token?: string };
 type BodyLike = QueryLike;
@@ -56,7 +56,7 @@ export default function getToken(
   const fromBody = getFromBody(body, urlEncoded);
 
   if (!fromQuery && !fromHeader && !fromBody) {
-    throw new InvalidRequestError('Bearer token is missing');
+    throw new UnauthorizedError();
   }
 
   if (+!!fromQuery + +!!fromBody + +!!fromHeader > 1) {

--- a/packages/oauth2-bearer/test/get-token.test.ts
+++ b/packages/oauth2-bearer/test/get-token.test.ts
@@ -54,7 +54,7 @@ describe('get-token', () => {
 
   it('should fail when there are no tokens', async () => {
     await expect(got(url)).rejects.toThrowError(
-      'Response code 400 (Bearer token is missing)'
+      'Response code 401 (Unauthorized)'
     );
   });
 
@@ -87,7 +87,7 @@ describe('get-token', () => {
           authorization: 'foo token',
         },
       })
-    ).rejects.toThrowError('Response code 400 (Bearer token is missing)');
+    ).rejects.toThrowError('Response code 401 (Unauthorized)');
   });
 
   it('should fail for empty header', async () => {
@@ -97,7 +97,7 @@ describe('get-token', () => {
           authorization: 'Bearer ',
         },
       })
-    ).rejects.toThrowError('Response code 400 (Bearer token is missing)');
+    ).rejects.toThrowError('Response code 401 (Unauthorized)');
   });
 
   it('should get the token from the query string', async () => {
@@ -135,7 +135,7 @@ describe('get-token', () => {
         method: 'POST',
         json: { access_token: 'token' },
       })
-    ).rejects.toThrowError('Response code 400 (Bearer token is missing)');
+    ).rejects.toThrowError('Response code 401 (Unauthorized)');
   });
 
   it('should succeed to get the token from request payload for GETs', async () => {


### PR DESCRIPTION
### Description

Have changed the errors you get when you don't provide a bearer token from `400: invalid_request` to a generic `401: Unauthorized` based on the recommendation in [rfc6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)

>  If the request lacks any authentication information (e.g., the client
   was unaware that authentication is necessary or attempted using an
   unsupported authentication method), the resource server SHOULD NOT
   include an error code or other error information.
> For example:
>     HTTP/1.1 401 Unauthorized
>     WWW-Authenticate: Bearer realm="example"

Have also changed the custom claim check error descriptions for when a claim isn't present in the token from `Unexpected 'foo' value` to `Missing 'foo' claim`, since the former was misleading.

### References

https://datatracker.ietf.org/doc/html/rfc6750#section-3.1

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
