### PR TITLE
Throw 403 when missing scope claim altogether

### DIFF
--- a/packages/access-token-jwt/src/claim-check.ts
+++ b/packages/access-token-jwt/src/claim-check.ts
@@ -50,6 +50,12 @@ export const requiredScopes: RequiredScopes = (scopes) => {
   }
   const fn = isClaimIncluded('scope', scopes);
   return claimCheck((payload) => {
+    if (!('scope' in payload)) {
+      throw new InsufficientScopeError(
+        scopes as string[],
+        "Missing 'scope' claim"
+      );
+    }
     if (!fn(payload)) {
       throw new InsufficientScopeError(scopes as string[]);
     }

--- a/packages/access-token-jwt/test/claim-check.test.ts
+++ b/packages/access-token-jwt/test/claim-check.test.ts
@@ -136,9 +136,9 @@ describe('claim-check', () => {
       );
     });
 
-    it('should expect a string or array of strings', () => {
-      expect(requiredScopes).toThrowError(
-        "scopes' must be a string or array of strings"
+    it('should throw if no scope claim found', () => {
+      expect(requiredScopes('foo bar').bind(null, { foo: 'bar' })).toThrowError(
+        new InsufficientScopeError(['foo', 'bar'], "Missing 'scope' claim")
       );
     });
 


### PR DESCRIPTION
### Description

The samples tests picked up an inconsistency with errors thrown when there's no scope claim

![image](https://user-images.githubusercontent.com/1299658/138059203-4d41c945-d052-41e2-b31a-84b7b9e7cbea.png)

It's not clear in the spec, but good to be consistent with the other libraries

### References

See https://app.circleci.com/pipelines/github/auth0-samples/auth0-express-api-samples/13/workflows/e620de05-9fe3-41a7-9143-4da4b95bed04/jobs/74
