### PR TITLE
Export error types [SDK-2941]

### DIFF
--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -78,18 +78,16 @@ export const auth = (opts: JwtVerifierOptions = {}): Handler => {
   };
 };
 
-const toHandler = (fn: (payload?: JWTPayload) => void): Handler => (
-  req,
-  res,
-  next
-) => {
-  try {
-    fn(req.auth?.payload);
-    next();
-  } catch (e) {
-    next(e);
-  }
-};
+const toHandler =
+  (fn: (payload?: JWTPayload) => void): Handler =>
+  (req, res, next) => {
+    try {
+      fn(req.auth?.payload);
+      next();
+    } catch (e) {
+      next(e);
+    }
+  };
 
 /**
  * Check the token's claims using a custom method that receives the
@@ -160,3 +158,9 @@ export {
   JWTHeader,
   JSONPrimitive,
 } from 'access-token-jwt';
+export {
+  UnauthorizedError,
+  InvalidRequestError,
+  InvalidTokenError,
+  InsufficientScopeError,
+} from 'oauth2-bearer';

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -13,6 +13,10 @@ import {
   claimEquals,
   claimIncludes,
   requiredScopes,
+  UnauthorizedError,
+  InvalidRequestError,
+  InvalidTokenError,
+  InsufficientScopeError,
 } from '../src';
 
 const expectFailsWith = async (
@@ -407,5 +411,20 @@ describe('index', () => {
       'invalid_token',
       "'nbf' claim must be a number"
     );
+  });
+
+  it('should export errors', () => {
+    expect(() => {
+      throw new UnauthorizedError();
+    }).toThrow(UnauthorizedError);
+    expect(() => {
+      throw new InvalidRequestError();
+    }).toThrow(InvalidRequestError);
+    expect(() => {
+      throw new InvalidTokenError();
+    }).toThrow(InvalidTokenError);
+    expect(() => {
+      throw new InsufficientScopeError();
+    }).toThrow(InsufficientScopeError);
   });
 });


### PR DESCRIPTION
### Description

Export `InsufficientScopeError`, `InvalidRequestError`, `InvalidTokenError`, `UnauthorizedError` from `express-oauth2-jwt-bearer`

### References

Required for https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
