### PR TITLE
docs(README): add node v16 as supported version

### DIFF
--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -21,7 +21,7 @@ Authentication middleware for Express.js that validates JWT Bearer Access Tokens
 
 ## Install
 
-This package supports Node `^12.19.0 || ^14.15.0`
+This package supports Node `^12.19.0 || ^14.15.0 || ^16.13.0`
 
 ```shell
 npm install express-oauth2-jwt-bearer


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Version 16 of node.js is [already added to package.json](https://github.com/auth0/node-oauth2-jwt-bearer/commit/ea55ef98b077d039cb4dffd3812b6c8caaac1f44) and I can confirm it works with that version.
