### PR TITLE
Support scope aliases

### DIFF
--- a/packages/access-token-jwt/src/claim-check.ts
+++ b/packages/access-token-jwt/src/claim-check.ts
@@ -48,15 +48,23 @@ export const requiredScopes: RequiredScopes = (scopes) => {
   } else if (!Array.isArray(scopes)) {
     throw new TypeError("'scopes' must be a string or array of strings");
   }
-  const fn = isClaimIncluded('scope', scopes);
+  const fn = (scope: string) => isClaimIncluded(scope, scopes as string[]);
   return claimCheck((payload) => {
-    if (!('scope' in payload)) {
+    let scopeField: string
+    if ('scp' in payload) {
+      scopeField = 'scp';
+    } else if ('scopes' in payload) {
+      scopeField = 'scopes';
+    } else if ('scope' in payload) {
+      scopeField = 'scope';
+    } else {
       throw new InsufficientScopeError(
-        scopes as string[],
-        "Missing 'scope' claim"
+          scopes as string[],
+          "Missing 'scope' claim"
       );
     }
-    if (!fn(payload)) {
+
+    if (!fn(scopeField)(payload)) {
       throw new InsufficientScopeError(scopes as string[]);
     }
     return true;

--- a/packages/access-token-jwt/test/claim-check.test.ts
+++ b/packages/access-token-jwt/test/claim-check.test.ts
@@ -156,11 +156,27 @@ describe('claim-check', () => {
       ).toThrowError(new InsufficientScopeError(['foo', 'bar']));
     });
 
-    it('should not throw if all scopes found in actual', () => {
+    it('should not throw if all scopes found in actual in scope alias', () => {
       expect(
         requiredScopes(['foo', 'bar']).bind(null, {
           scope: 'foo bar',
         })
+      ).not.toThrow();
+    });
+
+    it('should not throw if all scopes found in actual in scp alias', () => {
+      expect(
+          requiredScopes(['foo', 'bar']).bind(null, {
+            scp: 'foo bar',
+          })
+      ).not.toThrow();
+    });
+
+    it('should not throw if all scopes found in actual in scopes alias', () => {
+      expect(
+          requiredScopes(['foo', 'bar']).bind(null, {
+            scopes: 'foo bar',
+          })
       ).not.toThrow();
     });
   });

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -379,7 +379,7 @@ describe('index', () => {
     );
   });
 
-  it('should succeed when required scopes are included', async () => {
+  it('should succeed when required scopes are included in scope alias', async () => {
     const jwt = await createJwt({ payload: { scope: ['foo', 'bar', 'baz'] } });
     const baseUrl = await setup({
       middleware: requiredScopes('foo bar'),
@@ -394,6 +394,42 @@ describe('index', () => {
       expect.objectContaining({
         scope: ['foo', 'bar', 'baz'],
       })
+    );
+  });
+
+  it('should succeed when required scopes are included in scp alias', async () => {
+    const jwt = await createJwt({ payload: { scp: ['foo', 'bar', 'baz'] } });
+    const baseUrl = await setup({
+      middleware: requiredScopes('foo bar'),
+    });
+    const response = await got(baseUrl, {
+      headers: { authorization: `Bearer ${jwt}` },
+      responseType: 'json',
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty(
+        'payload',
+        expect.objectContaining({
+          scp: ['foo', 'bar', 'baz'],
+        })
+    );
+  });
+
+  it('should succeed when required scopes are included in scopes alias', async () => {
+    const jwt = await createJwt({ payload: { scopes: ['foo', 'bar', 'baz'] } });
+    const baseUrl = await setup({
+      middleware: requiredScopes('foo bar'),
+    });
+    const response = await got(baseUrl, {
+      headers: { authorization: `Bearer ${jwt}` },
+      responseType: 'json',
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty(
+        'payload',
+        expect.objectContaining({
+          scopes: ['foo', 'bar', 'baz'],
+        })
     );
   });
 


### PR DESCRIPTION
### Description

Some servers like Ory Hydra use `scp` as the scope field and it's not configurable.

### References

See [https://www.ory.sh/docs/hydra/guides/migrating-from-mitreid](https://www.ory.sh/docs/hydra/guides/migrating-from-mitreid)
