### PR TITLE
Document `req.auth`

### DIFF
--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -71,7 +71,7 @@ With this basic configuration, your api will require a valid Access Token JWT be
 
 ## API Documentation
 
-- [auth](https://auth0.github.io/node-oauth2-jwt-bearer#auth) - Middleware that will return a 401 if a valid Access token JWT bearer token is not provided in the request.
+- [auth](https://auth0.github.io/node-oauth2-jwt-bearer#auth) - Middleware that will return a 401 if a valid Access token JWT bearer token is not provided in the request. It will also populate `req.auth` with `{ payload, header, token }`.
 - [requiredScopes](https://auth0.github.io/node-oauth2-jwt-bearer#requiredscopes) - Check a token's scope claim to include a number of given scopes, raises a 403 `insufficient_scope` error if the value of the scope claim does not include all the given scopes.
 - [claimEquals](https://auth0.github.io/node-oauth2-jwt-bearer#claimequals) - Check a token's claim to be equal a given JSONPrimitive (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not match.
 - [claimIncludes](https://auth0.github.io/node-oauth2-jwt-bearer#claimincludes) - Check a token's claim to include a number of given JSONPrimitives (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not include all the given values.


### PR DESCRIPTION
I don't expect this to be merged as is, consider this more like a glorified issue I'm opening. This is not documented anywhere:

https://github.com/auth0/node-oauth2-jwt-bearer/blob/a2b9733b31bf802a06e07c4e521aaeb279a58a17/packages/express-oauth2-jwt-bearer/src/index.ts#L73

I was wondering how to access the JWT details and if I need another package. Turns out I don't. This should probably also be added to the [jsdoc](https://github.com/auth0/node-oauth2-jwt-bearer/blob/a2b9733b31bf802a06e07c4e521aaeb279a58a17/packages/express-oauth2-jwt-bearer/src/index.ts#L26-L62) so it appear in the API docs.