### PR TITLE
[SDK-3739] Update readmes to match new design

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+Contributions can be made to this library through PRs to fix issues, improve documentation or add features. Please fork this repo, create a well-named branch, and submit a PR with a complete template filled out.
+
+Code changes in PRs should be accompanied by tests covering the changed or added functionality. Tests can be run for this library with:
+
+```bash
+npm install
+npm test
+```
+
+When you're ready to push your changes, please run the lint command first:
+
+```bash
+npm run lint
+```
+
+## Developing
+
+This monorepo uses npm workspaces. You must have `npm >= @7.14` to develop this package
+
+To run a command in the context of a workspace from the root use the `--workspace` or `--workspaces` arguments.
+
+```shell
+# install jose on access-token-jwt
+npm run install jose --workspace=access-token-jwt
+
+# build oauth2-bearer
+npm run build --workspace=oauth2-bearer
+
+# run all tests
+npm test --workspaces # you can also use the `npm test` script
+```
+
+### Playground app
+
+```shell
+npm run dev --workspace=packages/examples
+```

--- a/README.md
+++ b/README.md
@@ -8,72 +8,36 @@ Monorepo for `oauth2-jwt-bearer`. Contains the following packages:
 | [access-token-jwt](./packages/access-token-jwt)                   |     ✘     | Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12) |
 | [express-oauth2-jwt-bearer](./packages/express-oauth2-jwt-bearer) |     ✔     | Authentication middleware for Express.js that validates JWT Bearer Access Tokens                                                                                 |
 
-## Developing
+## Feedback
 
-This monorepo uses npm workspaces. You must have `npm >= @7.14` to develop this package
-
-To run a command in the context of a workspace from the root use the `--workspace` or `--workspaces` arguments.
-
-```shell
-# install jose on access-token-jwt
-npm run install jose --workspace=access-token-jwt
-
-# build oauth2-bearer
-npm run build --workspace=oauth2-bearer
-
-# run all tests
-npm test --workspaces # you can also use the `npm test` script
-```
-
-### Playground app
-
-```shell
-npm run dev --workspace=packages/examples
-```
-
-## Contributing
+### Contributing
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:
 
-- [Auth0's general contribution guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md)
+- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 - [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
+- [This repo's contribution guide](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/CONTRIBUTING.md)
 
-Contributions can be made to this library through PRs to fix issues, improve documentation or add features. Please fork this repo, create a well-named branch, and submit a PR with a complete template filled out.
+### Raise an issue
 
-Code changes in PRs should be accompanied by tests covering the changed or added functionality. Tests can be run for this library with:
+To provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/node-oauth2-jwt-bearer/issues).
 
-```bash
-npm install
-npm test
-```
-
-When you're ready to push your changes, please run the lint command first:
-
-```bash
-npm run lint
-```
-
-## Support + Feedback
-
-Please use the [Issues queue](https://github.com/auth0/node-oauth2-jwt-bearer/issues) in this repo for questions and feedback.
-
-## Vulnerability Reporting
+### Vulnerability Reporting
 
 Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
 
 ## What is Auth0?
 
-Auth0 helps you to easily:
-
-- implement authentication with multiple identity providers, including social (e.g., Google, Facebook, Microsoft, LinkedIn, GitHub, Twitter, etc), or enterprise (e.g., Windows Azure AD, Google Apps, Active Directory, ADFS, SAML, etc.)
-- log in users with username/password databases, passwordless, or multi-factor authentication
-- link multiple user accounts together
-- generate signed JSON Web Tokens to authorize your API calls and flow the user identity securely
-- access demographics and analytics detailing how, when, and where users are logging in
-- enrich user profiles from other data sources using customizable JavaScript rules
-
-[Why Auth0?](https://auth0.com/why-auth0)
-
-## License
-
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png" width="150">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+    <img alt="Auth0 Logo" src="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+  </picture>
+</p>
+<p align="center">
+  Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href="https://auth0.com/why-auth0">Why Auth0?</a>
+</p>
+<p align="center">
+  This project is licensed under the MIT license. See the <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/LICENSE"> LICENSE</a> file for more info.
+</p>

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -1,0 +1,99 @@
+# Examples
+
+- [Restrict access with scopes](#restrict-access-with-scopes)
+- [Restrict access with claims](#restrict-access-with-claims)
+  - [Matching a specific value](#matching-a-specific-value)
+  - [Matching multiple values](#matching-multiple-values)
+  - [Matching custom logic](#matching-custom-logic)
+
+
+## Restrict access with scopes
+
+To restrict access based on the scopes a user has, use the `requiredScopes` middleware, raising a 403 `insufficient_scope` error if the value of the scope claim does not include all the given scopes.
+
+```js
+const {
+  auth,
+  requiredScopes
+} = require('express-oauth2-jwt-bearer');
+
+// Initialise the auth middleware with environment variables and restrict
+// access to your api to users with a valid Access Token JWT
+app.use(auth());
+
+// Restrict access to the messages api to users with the `read:msg`
+// AND `write:msg` scopes  
+app.get('/api/messages',
+    requiredScopes('read:msg', 'write:msg'),
+    (req, res, next) => {
+      // ...
+    }
+);
+```
+
+## Restrict access with claims
+
+### Matching a specific value
+
+To restrict access based on the value of a claim use the `claimEquals` middleware. This checks that the claim exists and matches the expected value, raising a 401 `invalid_token` error if the value of the claim does not match.
+
+```js
+const {
+  auth,
+  claimEquals
+} = require('express-oauth2-jwt-bearer');
+
+// Initialise the auth middleware with environment variables and restrict
+// access to your api to users with a valid Access Token JWT
+app.use(auth());
+
+// Restrict access to the admin api to users with the `isAdmin: true` claim
+app.get('/api/admin', claimEquals('isAdmin', true), (req, res, next) => {
+  // ...
+});
+```
+
+### Matching multiple values
+
+To restrict access based on a claim including multiple values use the `claimIncludes` middleware. This checks that the claim exists and the expected values are included, rasising a 401 `invalid_token` error if the value of the claim does not include all the given values
+
+
+```js
+const {
+  auth,
+  claimIncludes
+} = require('express-oauth2-jwt-bearer');
+
+// Initialise the auth middleware with environment variables and restrict
+// access to your api to users with a valid Access Token JWT
+app.use(auth());
+
+// Restrict access to the managers admin api to users with both the role `admin`
+// AND the role `manager`
+app.get('/api/admin/managers',
+    claimIncludes('role', 'admin', 'manager'),
+    (req, res, next) => {
+      // ...
+    }
+);
+```
+
+### Matching custom logic
+
+To restrict access based on custom logic you can provide a function use `claimCheck`. This must be a function that  receives the JWT Payload and should return `true` if the token is valid, raising a 401 `invalid_token` error if the function returns `false`.
+
+```js
+const {
+  auth,
+  claimCheck
+} = require('express-oauth2-jwt-bearer');
+
+// Restrict access to the admin edit api to users with the `isAdmin: true` claim
+// and the `editor` role.
+app.get('/api/admin/edit',
+    claimCheck(({ isAdmin, roles }) => isAdmin && roles.includes('editor')),
+    (req, res, next) => {
+      // ...
+   }
+);
+```

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -1,27 +1,27 @@
-# express-oauth2-jwt-bearer
+![Authentication middleware for Express.js that validates JWT Bearer Access Tokens](https://cdn.auth0.com/website/sdks/banners/express-oauth2-jwt-bearer-banner.png)
 
-Authentication middleware for Express.js that validates JWT Bearer Access Tokens.
-
-[![CircleCI](https://img.shields.io/circleci/build/github/auth0/node-oauth2-jwt-bearer.svg?branch=master&style=flat)](https://circleci.com/gh/auth0/node-oauth2-jwt-bearer)
-[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 [![npm](https://img.shields.io/npm/v/express-oauth2-jwt-bearer.svg?style=flat)](https://www.npmjs.com/package/express-oauth2-jwt-bearer)
 [![codecov](https://img.shields.io/badge/coverage-100%25-green)](./jest.config.js#L6-L13)
+![Downloads](https://img.shields.io/npm/dw/express-oauth2-jwt-bearer)
+[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
+[![CircleCI](https://img.shields.io/circleci/build/github/auth0/node-oauth2-jwt-bearer.svg?branch=master&style=flat)](https://circleci.com/gh/auth0/node-oauth2-jwt-bearer)
 
-- [Install](#install)
-- [Getting started](#getting-started)
-- [API Documentation](#api-documentation)
-- [Examples](#examples)
-- [Security Headers](#security-headers)
-- [Error Handling](#error-handling)
-- [Contributing](#contributing)
-- [Support + Feedback](#support---feedback)
-- [Vulnerability Reporting](#vulnerability-reporting)
-- [What is Auth0?](#what-is-auth0-)
-- [License](#license)
+📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💻 [API Reference](#api-reference) - 💬 [Feedback](#feedback)
 
-## Install
+## Documentation
 
-This package supports Node `^12.19.0 || ^14.15.0 || ^16.13.0`
+- [Docs Site](https://auth0.com/docs) - explore our Docs site and learn more about Auth0.
+
+## Getting started
+### Requirements
+
+This package supports the following tooling versions:
+
+- Node.js: `^12.19.0 || ^14.15.0 || ^16.13.0`
+
+### Installation
+
+Using [npm](https://npmjs.org) in your project directory run the following command:
 
 ```shell
 npm install express-oauth2-jwt-bearer
@@ -29,7 +29,11 @@ npm install express-oauth2-jwt-bearer
 
 ## Getting started
 
-The library requires [issuerBaseURL](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authoptions.html#issuerbaseurl) and [audience](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authoptions.html#audience), which can be configured with environmental variables:
+### Configure the SDK
+
+The library requires [issuerBaseURL](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authoptions.html#issuerbaseurl) and [audience](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authoptions.html#audience).
+
+#### Environment Variables
 
 ```shell
 ISSUER_BASE_URL=https://YOUR_ISSUER_DOMAIN
@@ -41,7 +45,7 @@ const { auth } = require('express-oauth2-jwt-bearer');
 app.use(auth());
 ```
 
-... or in the library initialization:
+#### Library Initialization
 
 ```js
 const { auth } = require('express-oauth2-jwt-bearer');
@@ -53,7 +57,7 @@ app.use(
 );
 ```
 
-... or for JWTs signed with symmetric algorithms (eg `HS256`)
+#### JWTs signed with symmetric algorithms (eg `HS256`)
 
 ```js
 const { auth } = require('express-oauth2-jwt-bearer');
@@ -67,7 +71,7 @@ app.use(
 );
 ```
 
-With this basic configuration, your api will require a valid Access Token JWT bearer token for all routes.
+With this configuration, your api will require a valid Access Token JWT bearer token for all routes.
 
 Successful requests will have the following properties added to them:
 
@@ -82,68 +86,11 @@ app.get('/api/messages',
 );
 ```
 
-## API Documentation
-
-- [auth](https://auth0.github.io/node-oauth2-jwt-bearer#auth) - Middleware that will return a 401 if a valid Access token JWT bearer token is not provided in the request.
-- [AuthResult](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authresult.html) - The properties added to `req.auth` upon successful authorization.
-- [requiredScopes](https://auth0.github.io/node-oauth2-jwt-bearer#requiredscopes) - Check a token's scope claim to include a number of given scopes, raises a 403 `insufficient_scope` error if the value of the scope claim does not include all the given scopes.
-- [claimEquals](https://auth0.github.io/node-oauth2-jwt-bearer#claimequals) - Check a token's claim to be equal a given JSONPrimitive (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not match.
-- [claimIncludes](https://auth0.github.io/node-oauth2-jwt-bearer#claimincludes) - Check a token's claim to include a number of given JSONPrimitives (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not include all the given values.
-- [claimCheck](https://auth0.github.io/node-oauth2-jwt-bearer#claimcheck) - Check the token's claims using a custom method that receives the JWT Payload and should return `true` if the token is valid. Raises a 401 `invalid_token` error if the function returns `false`.
-
-## Examples
-
-```js
-const {
-  auth,
-  requiredScopes,
-  claimEquals,
-  claimIncludes,
-  claimCheck
-} = require('express-oauth2-jwt-bearer');
-
-// Initialise the auth middleware with environment variables and restrict
-// access to your api to users with a valid Access Token JWT
-app.use(auth());
-
-// Restrict access to the messages api to users with the `read:msg`
-// AND `write:msg` scopes  
-app.get('/api/messages',
-    requiredScopes('read:msg', 'write:msg'),
-    (req, res, next) => {
-      // ...
-    }
-);
-
-// Restrict access to the admin api to users with the `isAdmin: true` claim
-app.get('/api/admin', claimEquals('isAdmin', true), (req, res, next) => {
-  // ...
-});
-
-// Restrict access to the managers admin api to users with both the role `admin`
-// AND the role `manager`
-app.get('/api/admin/managers',
-    claimIncludes('role', 'admin', 'manager'),
-    (req, res, next) => {
-      // ...
-    }
-);
-
-// Restrict access to the admin edit api to users with the `isAdmin: true` claim
-// and the `editor` role.
-app.get('/api/admin/edit',
-    claimCheck(({ isAdmin, roles }) => isAdmin && roles.includes('editor')),
-    (req, res, next) => {
-      // ...
-   }
-);
-```
-
-## Security Headers
+### Security Headers
 
 Along with the other [security best practices](https://expressjs.com/en/advanced/best-practice-security.html) in the Express.js documentation, we recommend you use [helmet](https://www.npmjs.com/package/helmet) in addition to this middleware which can help protect your app from some well-known web vulnerabilities by setting default security HTTP headers.
 
-## Error Handling
+### Error Handling
 
 This SDK raises errors with `err.status` and `err.headers` according to [rfc6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3). The Express.js default error handler will set the error response with:
 
@@ -156,31 +103,44 @@ The `error_description` in the `WWW-Authenticate` header will contain useful inf
 
 See the Express.js [docs on error handling](https://expressjs.com/en/guide/error-handling.html) for more information on writing custom error handlers.
 
-## Contributing
+## API Reference
 
-See monorepo's [contributing guidelines](../../README.md#contributing).
+- [auth](https://auth0.github.io/node-oauth2-jwt-bearer#auth) - Middleware that will return a 401 if a valid Access token JWT bearer token is not provided in the request.
+- [AuthResult](https://auth0.github.io/node-oauth2-jwt-bearer/interfaces/authresult.html) - The properties added to `req.auth` upon successful authorization.
+- [requiredScopes](https://auth0.github.io/node-oauth2-jwt-bearer#requiredscopes) - Check a token's scope claim to include a number of given scopes, raises a 403 `insufficient_scope` error if the value of the scope claim does not include all the given scopes.
+- [claimEquals](https://auth0.github.io/node-oauth2-jwt-bearer#claimequals) - Check a token's claim to be equal a given JSONPrimitive (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not match.
+- [claimIncludes](https://auth0.github.io/node-oauth2-jwt-bearer#claimincludes) - Check a token's claim to include a number of given JSONPrimitives (string, number, boolean or null) raises a 401 `invalid_token` error if the value of the claim does not include all the given values.
+- [claimCheck](https://auth0.github.io/node-oauth2-jwt-bearer#claimcheck) - Check the token's claims using a custom method that receives the JWT Payload and should return `true` if the token is valid. Raises a 401 `invalid_token` error if the function returns `false`.
 
-## Support + Feedback
+## Feedback
+### Contributing
 
-Please use the [Issues queue](https://github.com/auth0/node-oauth2-jwt-bearer/issues) in this repo for questions and feedback.
+We appreciate feedback and contribution to this repo! Before you get started, please see the following:
 
-## Vulnerability Reporting
+- [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
+- [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
+- [This repo's contribution guide](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/CONTRIBUTING.md)
+
+### Raise an issue
+
+To provide feedback or report a bug, please [raise an issue on our issue tracker](https://github.com/auth0/node-oauth2-jwt-bearer/issues).
+
+### Vulnerability Reporting
 
 Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
 
 ## What is Auth0?
 
-Auth0 helps you to easily:
-
-- implement authentication with multiple identity providers, including social (e.g., Google, Facebook, Microsoft, LinkedIn, GitHub, Twitter, etc), or enterprise (e.g., Windows Azure AD, Google Apps, Active Directory, ADFS, SAML, etc.)
-- log in users with username/password databases, passwordless, or multi-factor authentication
-- link multiple user accounts together
-- generate signed JSON Web Tokens to authorize your API calls and flow the user identity securely
-- access demographics and analytics detailing how, when, and where users are logging in
-- enrich user profiles from other data sources using customizable JavaScript rules
-
-[Why Auth0?](https://auth0.com/why-auth0)
-
-## License
-
-This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_dark_mode.png" width="150">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+    <img alt="Auth0 Logo" src="https://cdn.auth0.com/website/sdks/logos/auth0_light_mode.png" width="150">
+  </picture>
+</p>
+<p align="center">
+  Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href="https://auth0.com/why-auth0">Why Auth0?</a>
+</p>
+<p align="center">
+  This project is licensed under the MIT license. See the <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/LICENSE"> LICENSE</a> file for more info.
+</p>


### PR DESCRIPTION
### Description

Updates the top level and express-oauth2-jwt-bearer readmes to match the new design.

For the top level readme only the `Feedback` and `What is Auth0?` are left, given that it's a small readme I left out the navigation links.

For the express-oauth2-jwt-bearer I've moved the examples out to a separate document, but kept the `Security Headers` and `Error Handling` sections as part of `Getting Started`

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
