### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## [v1.2.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.2.0) (2022-10-27)
+
+**Added**
+- Add 18 LTS to engines [\#80](https://github.com/auth0/node-oauth2-jwt-bearer/pull/80) ([adamjmcgrath](https://github.com/adamjmcgrath))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-jwt-bearer",
-  "version": "0.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-jwt-bearer",
-      "version": "0.0.1",
+      "version": "1.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/oauth2-bearer",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "author": "Auth0 <support@auth0.com>",
-  "version": "0.0.1",
+  "version": "1.2.0",
   "workspaces": [
     "packages/oauth2-bearer",
     "packages/access-token-jwt",


### PR DESCRIPTION

**Added**
- Add 18 LTS to engines [\#80](https://github.com/auth0/node-oauth2-jwt-bearer/pull/80) ([adamjmcgrath](https://github.com/adamjmcgrath))
