### PR TITLE
Add scopeIncludesAny middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -600,6 +600,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -1187,10 +1209,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -6741,46 +6781,63 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "bin": {
@@ -6810,6 +6867,15 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ts-node/node_modules/diff": {
@@ -7098,6 +7164,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -7417,9 +7489,9 @@
       }
     },
     "packages/access-token-jwt/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7445,7 +7517,7 @@
         "got": "^11.8.5",
         "jose": "^4.9.2",
         "prettier": "~2.5.1",
-        "ts-node-dev": "^1.1.8",
+        "ts-node-dev": "^2.0.0",
         "tslib": "^2.3.1",
         "typescript": "^4.5.4"
       },
@@ -7454,9 +7526,9 @@
       }
     },
     "packages/examples/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7500,9 +7572,9 @@
       }
     },
     "packages/express-oauth2-jwt-bearer/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7539,9 +7611,9 @@
       }
     },
     "packages/oauth2-bearer/node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7994,6 +8066,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
@@ -8457,10 +8550,28 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -8920,9 +9031,9 @@
       },
       "dependencies": {
         "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+          "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
           "dev": true
         }
       }
@@ -10049,15 +10160,15 @@
         "got": "^11.8.5",
         "jose": "^4.9.2",
         "prettier": "~2.5.1",
-        "ts-node-dev": "^1.1.8",
+        "ts-node-dev": "^2.0.0",
         "tslib": "^2.3.1",
         "typescript": "^4.5.4"
       },
       "dependencies": {
         "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+          "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
           "dev": true
         }
       }
@@ -10189,9 +10300,9 @@
       },
       "dependencies": {
         "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+          "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
           "dev": true
         }
       }
@@ -11852,9 +11963,9 @@
       },
       "dependencies": {
         "typescript": {
-          "version": "4.7.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-          "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+          "version": "4.9.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+          "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
           "dev": true
         }
       }
@@ -12824,19 +12935,32 @@
       }
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -12846,20 +12970,20 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -13074,6 +13198,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -21,6 +21,7 @@ export {
   ClaimIncludes,
   requiredScopes,
   RequiredScopes,
+  scopeIncludesAny,
   JSONPrimitive,
 } from './claim-check';
 export { FunctionValidator, Validator, Validators } from './validate';

--- a/packages/access-token-jwt/test/claim-check.test.ts
+++ b/packages/access-token-jwt/test/claim-check.test.ts
@@ -3,6 +3,7 @@ import {
   claimEquals,
   claimIncludes,
   requiredScopes,
+  scopeIncludesAny,
   UnauthorizedError,
   InvalidTokenError,
   InsufficientScopeError,
@@ -164,4 +165,48 @@ describe('claim-check', () => {
       ).not.toThrow();
     });
   });
+
+  describe('scopeIncludesAny', () => {
+    it('should expect a string or array of strings', () => {
+      expect(scopeIncludesAny).toThrowError(
+        "scopes' must be a string or array of strings"
+      );
+    });
+
+    it('should throw if no scope claim found', () => {
+      expect(scopeIncludesAny('foo bar').bind(null, { foo: 'bar' })).toThrowError(
+        new InsufficientScopeError(['foo', 'bar'], "Missing 'scope' claim")
+      );
+    });
+
+    it('should throw if all scopes from string not found in actual', () => {
+      expect(
+        scopeIncludesAny('foo bar').bind(null, { scope: 'baz' })
+      ).toThrowError(new InsufficientScopeError(['foo', 'bar']));
+    });
+
+    it('should throw if no scopes from array not found in actual', () => {
+      expect(
+        scopeIncludesAny(['foo', 'bar']).bind(null, {
+          scope: 'baz',
+        })
+      ).toThrowError(new InsufficientScopeError(['foo', 'bar']));
+    });
+
+    it('should not throw if all scopes found in actual', () => {
+      expect(
+        scopeIncludesAny(['foo', 'bar']).bind(null, {
+          scope: 'foo bar',
+        })
+      ).not.toThrow();
+    });
+
+    it('should not throw if any scopes found in actual', () => {
+      expect(
+        scopeIncludesAny(['foo', 'bar']).bind(null, {
+          scope: 'foo qux quxx',
+        })
+      ).not.toThrow();
+    });
+  })
 });

--- a/packages/examples/express-api.ts
+++ b/packages/examples/express-api.ts
@@ -1,6 +1,7 @@
 import {
   auth,
   requiredScopes,
+  scopeIncludesAny,
   claimEquals,
   claimIncludes,
 } from 'express-oauth2-jwt-bearer';
@@ -28,6 +29,13 @@ app.use(
 app.get('/auth', requiresAuth, handler);
 
 app.get('/scope', requiresAuth, requiredScopes('read:msg'), handler);
+
+app.get(
+  '/any-scope',
+  requiresAuth,
+  scopeIncludesAny(['read:msg', 'audit:read']),
+  handler
+);
 
 app.get('/claim-equals', requiresAuth, claimEquals('foo', 'bar'), handler);
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -25,7 +25,7 @@
     "got": "^11.8.5",
     "jose": "^4.9.2",
     "prettier": "~2.5.1",
-    "ts-node-dev": "^1.1.8",
+    "ts-node-dev": "^2.0.0",
     "tslib": "^2.3.1",
     "typescript": "^4.5.4"
   },

--- a/packages/examples/playground.ejs
+++ b/packages/examples/playground.ejs
@@ -49,6 +49,7 @@
           <legend>Express</legend>
           <button onclick="request(3001, '/auth')">auth()</button>
           <button onclick="request(3001, '/scope')">requiredScopes('read:msg')</button>
+          <button onclick="request(3001, '/any-scope')">scopeIncludesAny(['read:msg', 'audit:read'])</button>
           <button onclick="request(3001, '/claim-equals')">claimEquals('foo', 'bar')</button>
           <button onclick="request(3001, '/claim-includes')">claimIncludes('foo', 'bar', 'baz')</button>
           <button onclick="request(3001, '/custom')">auth({ validators: { iss: false } })</button>

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -10,6 +10,7 @@ import {
   ClaimIncludes,
   requiredScopes as _requiredScopes,
   RequiredScopes,
+  scopeIncludesAny as _scopeIncludesAny,
   VerifyJwtResult as AuthResult,
 } from 'access-token-jwt';
 import type { JWTPayload } from 'access-token-jwt';
@@ -137,7 +138,7 @@ export const claimIncludes: ClaimIncludes<Handler> = (...args) =>
 
 /**
  * Check a token's `scope` claim to include a number of given scopes, raises a
- * 401 `insufficient_scope` error if the value of the `scope` claim does not
+ * 403 `insufficient_scope` error if the value of the `scope` claim does not
  * include all the given scopes.
  *
  * ```js
@@ -149,6 +150,21 @@ export const claimIncludes: ClaimIncludes<Handler> = (...args) =>
  */
 export const requiredScopes: RequiredScopes<Handler> = (...args) =>
   toHandler(_requiredScopes(...args));
+
+/**
+ * Check a token's `scope` claim to include any of the given scopes, raises a
+ * 403 `insufficient_scope` error if the value of the `scope` claim does not
+ * include any the given scopes.
+ *
+ * ```js
+ * app.use(auth());
+ *
+ * app.get('/admin/edit', requiredScopes('read:admin write:admin'),
+ *    (req, res) => { ... });
+ * ```
+ */
+export const scopeIncludesAny: RequiredScopes<Handler> = (...args) =>
+  toHandler(_scopeIncludesAny(...args));
 
 export { JwtVerifierOptions as AuthOptions, AuthResult, JWTPayload };
 export {

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -159,7 +159,7 @@ export const requiredScopes: RequiredScopes<Handler> = (...args) =>
  * ```js
  * app.use(auth());
  *
- * app.get('/admin/edit', requiredScopes('read:admin write:admin'),
+ * app.get('/admin/edit', scopeIncludesAny('read:msg read:admin'),
  *    (req, res) => { ... });
  * ```
  */

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -154,7 +154,7 @@ export const requiredScopes: RequiredScopes<Handler> = (...args) =>
 /**
  * Check a token's `scope` claim to include any of the given scopes, raises a
  * 403 `insufficient_scope` error if the value of the `scope` claim does not
- * include any the given scopes.
+ * include any of the given scopes.
  *
  * ```js
  * app.use(auth());


### PR DESCRIPTION
### Description

The `scopeIncludesAny`  middleware checks a token's scope claim against the provided values raising a 403 `insufficient_scope` error if none of the provided values exist in the scope claim, if any of the provided values exist then it will provide access.

Also updates `ts-node-dev` in `packages/examples` to fix an issue with newer TypeScript versions.

### References

#83

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
