### PR TITLE
Recovery from invalid and temporarily unavailable OpenID discovery do…

### DIFF
--- a/packages/access-token-jwt/src/discovery.ts
+++ b/packages/access-token-jwt/src/discovery.ts
@@ -63,4 +63,15 @@ const discover = async (
   throw new Error('Failed to fetch authorization server metadata');
 };
 
+export const defaultDiscoveryDocumentValidator = async (maybeDiscoveryDocument: unknown): Promise<IssuerMetadata> => {
+  if (!maybeDiscoveryDocument || typeof(maybeDiscoveryDocument) !== 'object') {
+    throw new Error('Discovery document of unexpected type: ' + typeof(maybeDiscoveryDocument));
+  }
+  const invalidProperties = ['issuer', 'jwks_uri'].filter(p => !(p in maybeDiscoveryDocument && typeof((maybeDiscoveryDocument as Record<typeof p, unknown>)[p])==='string'));
+  if (invalidProperties.length > 0) {
+    throw new Error('Discovery document had invalid of missing properties: ' + invalidProperties.join(', '));
+  }
+  return maybeDiscoveryDocument as IssuerMetadata;
+};
+
 export default discover;

--- a/packages/access-token-jwt/test/discovery.test.ts
+++ b/packages/access-token-jwt/test/discovery.test.ts
@@ -1,5 +1,6 @@
 import nock = require('nock');
 import { discover } from '../src';
+import { defaultDiscoveryDocumentValidator } from '../src/discovery';
 
 const success = { issuer: 'https://op.example.com' };
 
@@ -186,5 +187,35 @@ describe('discover', () => {
     ).rejects.toThrowError(
       "'issuer' not found in authorization server metadata"
     );
+  });
+
+  it('unexpected type for discovery documents not accepted', async () => {
+    await expect(
+      defaultDiscoveryDocumentValidator('test')
+    ).rejects.toThrowError('Discovery document of unexpected type');
+  });
+
+  it('missing issuer for discovery documents not accepted', async () => {
+    await expect(
+      defaultDiscoveryDocumentValidator({ jwks_uri: 'https://example' })
+    ).rejects.toThrowError('Discovery document had invalid of missing properties: issuer');
+  });
+  
+  it('unexpected issuer for discovery documents not accepted', async () => {
+    await expect(
+      defaultDiscoveryDocumentValidator({ jwks_uri: 'https://example', issuer: 5 })
+    ).rejects.toThrowError('Discovery document had invalid of missing properties: issuer');
+  });
+  
+  it('missing jwks_uri for discovery documents not accepted', async () => {
+    await expect(
+      defaultDiscoveryDocumentValidator({ issuer: 'https://example' })
+    ).rejects.toThrowError('Discovery document had invalid of missing properties: jwks_uri');
+  });
+  
+  it('unexpected jwks_uri for discovery documents not accepted', async () => {
+    await expect(
+      defaultDiscoveryDocumentValidator({ issuer: 'https://example', jwks_uri: {} })
+    ).rejects.toThrowError('Discovery document had invalid of missing properties: jwks_uri');
   });
 });


### PR DESCRIPTION
…cuments. #93

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This allows the code to recover from temporarily unavailable OpenID discovery documents. The max-age as suggested in #93 is not part of this PR.


### References

Ticket #93 

### Testing

Test by setting up a flaky server or trust the added unit test `should recover from failing to download OpenID discovery docuent` in `jwt-verifier.test.ts`.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
