### PR TITLE
Release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7597,7 +7597,7 @@
       }
     },
     "packages/examples": {
-      "version": "0.0.1",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/node12": "^1.0.11",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## [v1.4.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.4.0) (2023-04-03)
+
+**Added**
+- Cache max age [\#98](https://github.com/auth0/node-oauth2-jwt-bearer/pull/98) ([adamjmcgrath](https://github.com/adamjmcgrath))
+- Add authRequired option [\#97](https://github.com/auth0/node-oauth2-jwt-bearer/pull/97) ([adamjmcgrath](https://github.com/adamjmcgrath))

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "author": "Auth0 <support@auth0.com>",
-  "version": "0.0.1",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION

**Added**
- Cache max age [\#98](https://github.com/auth0/node-oauth2-jwt-bearer/pull/98) ([adamjmcgrath](https://github.com/adamjmcgrath))
- Add authRequired option [\#97](https://github.com/auth0/node-oauth2-jwt-bearer/pull/97) ([adamjmcgrath](https://github.com/adamjmcgrath))
