### PR TITLE
nbf claim validation should include clockTolerance

### DIFF
--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -246,7 +246,8 @@ const jwtVerifier = ({
       };
       const { payload, protectedHeader: header } = await jwtVerify(
         jwt,
-        getKeyFnGetter(jwksUri)
+        getKeyFnGetter(jwksUri),
+        { clockTolerance }
       );
       await validate(payload, header, validators);
       return { payload, header, token: jwt };


### PR DESCRIPTION
### Description

Pass `clockTolerance` option through to `jose` so that additional JWT date claims (like `nbf`) get validated with clock tolerance.

### References

fixes #113 
