### PR TITLE
Ensure to scan all projects with Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -45,3 +45,5 @@ jobs:
       - uses: snyk/actions/php@b98d498629f1c368650224d6d212bf7dfa89e4bf # pin@0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects


### PR DESCRIPTION
### Description

Currently, Snyk only scans the root.

![image](https://github.com/auth0/node-oauth2-jwt-bearer/assets/2146903/7c2d566d-0a87-4e15-b044-96362fee7d1f)

This PR adds the `--all-projects` flag to ensure it scans all projects.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
