### PR TITLE
Release FOOBAR-v1.6.1

### DIFF
--- a/docs/classes/InsufficientScopeError.html
+++ b/docs/classes/InsufficientScopeError.html
@@ -26,7 +26,7 @@ access token.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">InsufficientScopeError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L57">packages/oauth2-bearer/src/errors.ts:57</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L57">packages/oauth2-bearer/src/errors.ts:57</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -69,14 +69,14 @@ access token.</p>
 <h4 class="tsd-returns-title">Returns <a href="InsufficientScopeError.html" class="tsd-signature-type tsd-kind-class">InsufficientScopeError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L62">packages/oauth2-bearer/src/errors.ts:62</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L62">packages/oauth2-bearer/src/errors.ts:62</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member"><a id="code" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>code</span><a href="#code" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#39;insufficient_scope&#39;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L58">packages/oauth2-bearer/src/errors.ts:58</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L58">packages/oauth2-bearer/src/errors.ts:58</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="headers" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>headers</span><a href="#headers" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">headers</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span><span class="tsd-kind-property">WWW-Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -87,7 +87,7 @@ access token.</p>
 <h5><span class="tsd-kind-property">WWW-<wbr/>Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#headers">headers</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="message" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>message</span><a href="#message" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">message</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
@@ -111,13 +111,13 @@ access token.</p>
 <div class="tsd-signature"><span class="tsd-kind-property">status</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 403</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#status">status</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L59">packages/oauth2-bearer/src/errors.ts:59</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L59">packages/oauth2-bearer/src/errors.ts:59</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="statusCode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>status<wbr/>Code</span><a href="#statusCode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">status<wbr/>Code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 403</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#statusCode">statusCode</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L60">packages/oauth2-bearer/src/errors.ts:60</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L60">packages/oauth2-bearer/src/errors.ts:60</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="prepareStackTrace" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagOptional">Optional</code> <span>prepare<wbr/>Stack<wbr/>Trace</span><a href="#prepareStackTrace" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">prepare<wbr/>Stack<wbr/>Trace</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">err</span>, <span class="tsd-kind-parameter">stackTraces</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span></div>

--- a/docs/classes/InvalidRequestError.html
+++ b/docs/classes/InvalidRequestError.html
@@ -28,7 +28,7 @@ token, or is otherwise malformed.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">InvalidRequestError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L27">packages/oauth2-bearer/src/errors.ts:27</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L27">packages/oauth2-bearer/src/errors.ts:27</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -69,14 +69,14 @@ token, or is otherwise malformed.</p>
 <h4 class="tsd-returns-title">Returns <a href="InvalidRequestError.html" class="tsd-signature-type tsd-kind-class">InvalidRequestError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L32">packages/oauth2-bearer/src/errors.ts:32</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L32">packages/oauth2-bearer/src/errors.ts:32</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member"><a id="code" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>code</span><a href="#code" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#39;invalid_request&#39;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L28">packages/oauth2-bearer/src/errors.ts:28</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L28">packages/oauth2-bearer/src/errors.ts:28</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="headers" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>headers</span><a href="#headers" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">headers</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span><span class="tsd-kind-property">WWW-Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -87,7 +87,7 @@ token, or is otherwise malformed.</p>
 <h5><span class="tsd-kind-property">WWW-<wbr/>Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#headers">headers</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="message" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>message</span><a href="#message" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">message</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
@@ -111,13 +111,13 @@ token, or is otherwise malformed.</p>
 <div class="tsd-signature"><span class="tsd-kind-property">status</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 400</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#status">status</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L29">packages/oauth2-bearer/src/errors.ts:29</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L29">packages/oauth2-bearer/src/errors.ts:29</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="statusCode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>status<wbr/>Code</span><a href="#statusCode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">status<wbr/>Code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 400</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#statusCode">statusCode</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L30">packages/oauth2-bearer/src/errors.ts:30</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L30">packages/oauth2-bearer/src/errors.ts:30</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="prepareStackTrace" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagOptional">Optional</code> <span>prepare<wbr/>Stack<wbr/>Trace</span><a href="#prepareStackTrace" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">prepare<wbr/>Stack<wbr/>Trace</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">err</span>, <span class="tsd-kind-parameter">stackTraces</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span></div>

--- a/docs/classes/InvalidTokenError.html
+++ b/docs/classes/InvalidTokenError.html
@@ -26,7 +26,7 @@ invalid for other reasons.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">InvalidTokenError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L42">packages/oauth2-bearer/src/errors.ts:42</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L42">packages/oauth2-bearer/src/errors.ts:42</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -67,14 +67,14 @@ invalid for other reasons.</p>
 <h4 class="tsd-returns-title">Returns <a href="InvalidTokenError.html" class="tsd-signature-type tsd-kind-class">InvalidTokenError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L47">packages/oauth2-bearer/src/errors.ts:47</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L47">packages/oauth2-bearer/src/errors.ts:47</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member"><a id="code" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>code</span><a href="#code" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &#39;invalid_token&#39;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L43">packages/oauth2-bearer/src/errors.ts:43</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L43">packages/oauth2-bearer/src/errors.ts:43</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="headers" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>headers</span><a href="#headers" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">headers</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span><span class="tsd-kind-property">WWW-Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span><span class="tsd-signature-symbol"> = ...</span></div>
@@ -85,7 +85,7 @@ invalid for other reasons.</p>
 <h5><span class="tsd-kind-property">WWW-<wbr/>Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#headers">headers</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="message" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>message</span><a href="#message" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">message</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
@@ -109,13 +109,13 @@ invalid for other reasons.</p>
 <div class="tsd-signature"><span class="tsd-kind-property">status</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 401</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#status">status</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L44">packages/oauth2-bearer/src/errors.ts:44</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L44">packages/oauth2-bearer/src/errors.ts:44</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="statusCode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>status<wbr/>Code</span><a href="#statusCode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">status<wbr/>Code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 401</span></div><aside class="tsd-sources">
 <p>Overrides <a href="UnauthorizedError.html">UnauthorizedError</a>.<a href="UnauthorizedError.html#statusCode">statusCode</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L45">packages/oauth2-bearer/src/errors.ts:45</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L45">packages/oauth2-bearer/src/errors.ts:45</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="prepareStackTrace" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagOptional">Optional</code> <span>prepare<wbr/>Stack<wbr/>Trace</span><a href="#prepareStackTrace" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">prepare<wbr/>Stack<wbr/>Trace</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">err</span>, <span class="tsd-kind-parameter">stackTraces</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span></div>

--- a/docs/classes/UnauthorizedError.html
+++ b/docs/classes/UnauthorizedError.html
@@ -31,7 +31,7 @@ other error information.</p>
 <li><a href="InvalidTokenError.html" class="tsd-signature-type tsd-kind-class">InvalidTokenError</a></li>
 <li><a href="InsufficientScopeError.html" class="tsd-signature-type tsd-kind-class">InsufficientScopeError</a></li></ul></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L10">packages/oauth2-bearer/src/errors.ts:10</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L10">packages/oauth2-bearer/src/errors.ts:10</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -71,7 +71,7 @@ other error information.</p>
 <h4 class="tsd-returns-title">Returns <a href="UnauthorizedError.html" class="tsd-signature-type tsd-kind-class">UnauthorizedError</a></h4><aside class="tsd-sources">
 <p>Overrides Error.constructor</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L15">packages/oauth2-bearer/src/errors.ts:15</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L15">packages/oauth2-bearer/src/errors.ts:15</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member"><a id="headers" class="tsd-anchor"></a>
@@ -83,7 +83,7 @@ other error information.</p>
 <li class="tsd-parameter">
 <h5><span class="tsd-kind-property">WWW-<wbr/>Authenticate</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L13">packages/oauth2-bearer/src/errors.ts:13</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="message" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>message</span><a href="#message" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">message</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
@@ -106,12 +106,12 @@ other error information.</p>
 <h3 class="tsd-anchor-link"><span>status</span><a href="#status" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">status</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 401</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L11">packages/oauth2-bearer/src/errors.ts:11</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L11">packages/oauth2-bearer/src/errors.ts:11</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="statusCode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>status<wbr/>Code</span><a href="#statusCode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">status<wbr/>Code</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 401</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/oauth2-bearer/src/errors.ts#L12">packages/oauth2-bearer/src/errors.ts:12</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/oauth2-bearer/src/errors.ts#L12">packages/oauth2-bearer/src/errors.ts:12</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited tsd-is-external"><a id="prepareStackTrace" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <code class="tsd-tag ts-flagOptional">Optional</code> <span>prepare<wbr/>Stack<wbr/>Trace</span><a href="#prepareStackTrace" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">prepare<wbr/>Stack<wbr/>Trace</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-kind-parameter">err</span>, <span class="tsd-kind-parameter">stackTraces</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span></div>

--- a/docs/functions/auth.html
+++ b/docs/functions/auth.html
@@ -51,7 +51,7 @@ used to match against the Access Token&#39;s <code>aud</code> claim.</p>
 <h5><span class="tsd-kind-parameter">opts</span>: <a href="../interfaces/AuthOptions.html" class="tsd-signature-type tsd-kind-interface">AuthOptions</a><span class="tsd-signature-symbol"> = {}</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/express-oauth2-jwt-bearer/src/index.ts#L82">packages/express-oauth2-jwt-bearer/src/index.ts:82</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/express-oauth2-jwt-bearer/src/index.ts#L82">packages/express-oauth2-jwt-bearer/src/index.ts:82</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/claimCheck.html
+++ b/docs/functions/claimCheck.html
@@ -46,7 +46,7 @@ customise the <code>error_description</code> which should be formatted per rfc67
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> <span class="tsd-kind-parameter">errMsg</span>: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L126">packages/access-token-jwt/src/claim-check.ts:126</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L126">packages/access-token-jwt/src/claim-check.ts:126</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/claimEquals.html
+++ b/docs/functions/claimEquals.html
@@ -34,7 +34,7 @@ error if the value of the claim does not match.</p>
 <h5><span class="tsd-kind-parameter">expected</span>: <a href="../types/JSONPrimitive.html" class="tsd-signature-type tsd-kind-type-alias">JSONPrimitive</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L107">packages/access-token-jwt/src/claim-check.ts:107</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L107">packages/access-token-jwt/src/claim-check.ts:107</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/claimIncludes.html
+++ b/docs/functions/claimIncludes.html
@@ -34,7 +34,7 @@ error if the value of the claim does not include all the given values.</p>
 <h5><code class="tsd-tag ts-flagRest">Rest</code> <span class="tsd-signature-symbol">...</span><span class="tsd-kind-parameter">expected</span>: <a href="../types/JSONPrimitive.html" class="tsd-signature-type tsd-kind-type-alias">JSONPrimitive</a><span class="tsd-signature-symbol">[]</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L90">packages/access-token-jwt/src/claim-check.ts:90</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L90">packages/access-token-jwt/src/claim-check.ts:90</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/requiredScopes.html
+++ b/docs/functions/requiredScopes.html
@@ -32,7 +32,7 @@ include all the given scopes.</p>
 <h5><span class="tsd-kind-parameter">scopes</span>: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L46">packages/access-token-jwt/src/claim-check.ts:46</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L46">packages/access-token-jwt/src/claim-check.ts:46</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/functions/scopeIncludesAny.html
+++ b/docs/functions/scopeIncludesAny.html
@@ -32,7 +32,7 @@ include any of the given scopes.</p>
 <h5><span class="tsd-kind-parameter">scopes</span>: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type ">Handler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L46">packages/access-token-jwt/src/claim-check.ts:46</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L46">packages/access-token-jwt/src/claim-check.ts:46</a></li></ul></aside></li></ul></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/interfaces/AuthOptions.html
+++ b/docs/interfaces/AuthOptions.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">AuthOptions</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/express-oauth2-jwt-bearer/src/index.ts#L19">packages/express-oauth2-jwt-bearer/src/index.ts:19</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/express-oauth2-jwt-bearer/src/index.ts#L19">packages/express-oauth2-jwt-bearer/src/index.ts:19</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -56,7 +56,7 @@ https.get method options. Use when behind an http(s) proxy.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.agent</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L48">packages/access-token-jwt/src/jwt-verifier.ts:48</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L48">packages/access-token-jwt/src/jwt-verifier.ts:48</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="audience" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>audience</span><a href="#audience" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">audience</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
@@ -65,7 +65,7 @@ REQUIRED: You can also provide the <code>AUDIENCE</code> environment variable.</
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.audience</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L27">packages/access-token-jwt/src/jwt-verifier.ts:27</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L27">packages/access-token-jwt/src/jwt-verifier.ts:27</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="authRequired" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>auth<wbr/>Required</span><a href="#authRequired" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">auth<wbr/>Required</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -73,7 +73,7 @@ REQUIRED: You can also provide the <code>AUDIENCE</code> environment variable.</
 Defaults to true.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/express-oauth2-jwt-bearer/src/index.ts#L24">packages/express-oauth2-jwt-bearer/src/index.ts:24</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/express-oauth2-jwt-bearer/src/index.ts#L24">packages/express-oauth2-jwt-bearer/src/index.ts:24</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="cacheMaxAge" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cache<wbr/>Max<wbr/>Age</span><a href="#cacheMaxAge" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">cache<wbr/>Max<wbr/>Age</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -83,7 +83,7 @@ Default is 600000 (10 minutes).</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.cacheMaxAge</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L69">packages/access-token-jwt/src/jwt-verifier.ts:69</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L69">packages/access-token-jwt/src/jwt-verifier.ts:69</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="clockTolerance" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>clock<wbr/>Tolerance</span><a href="#clockTolerance" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">clock<wbr/>Tolerance</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -92,7 +92,7 @@ Defaults to 5 secs.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.clockTolerance</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L98">packages/access-token-jwt/src/jwt-verifier.ts:98</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L98">packages/access-token-jwt/src/jwt-verifier.ts:98</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="cooldownDuration" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cooldown<wbr/>Duration</span><a href="#cooldownDuration" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">cooldown<wbr/>Duration</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -102,7 +102,7 @@ Default is 30000.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.cooldownDuration</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L55">packages/access-token-jwt/src/jwt-verifier.ts:55</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L55">packages/access-token-jwt/src/jwt-verifier.ts:55</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="issuer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>issuer</span><a href="#issuer" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">issuer</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -112,7 +112,7 @@ You can also provide the <code>ISSUER</code> environment variable.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.issuer</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L34">packages/access-token-jwt/src/jwt-verifier.ts:34</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L34">packages/access-token-jwt/src/jwt-verifier.ts:34</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="issuerBaseURL" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>issuer<wbr/>BaseURL</span><a href="#issuerBaseURL" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">issuer<wbr/>BaseURL</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -126,7 +126,7 @@ You can also provide the <code>ISSUER_BASE_URL</code> environment variable.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.issuerBaseURL</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L21">packages/access-token-jwt/src/jwt-verifier.ts:21</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L21">packages/access-token-jwt/src/jwt-verifier.ts:21</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="jwksUri" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>jwks<wbr/>Uri</span><a href="#jwksUri" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">jwks<wbr/>Uri</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -137,7 +137,7 @@ You can also provide the <code>JWKS_URI</code> environment variable.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.jwksUri</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L42">packages/access-token-jwt/src/jwt-verifier.ts:42</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L42">packages/access-token-jwt/src/jwt-verifier.ts:42</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="maxTokenAge" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>max<wbr/>Token<wbr/>Age</span><a href="#maxTokenAge" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">max<wbr/>Token<wbr/>Age</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -146,7 +146,7 @@ be accepted.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.maxTokenAge</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L104">packages/access-token-jwt/src/jwt-verifier.ts:104</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L104">packages/access-token-jwt/src/jwt-verifier.ts:104</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="secret" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>secret</span><a href="#secret" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">secret</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -155,7 +155,7 @@ By default this SDK validates tokens signed with asymmetric algorithms.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.secret</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L118">packages/access-token-jwt/src/jwt-verifier.ts:118</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L118">packages/access-token-jwt/src/jwt-verifier.ts:118</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="strict" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>strict</span><a href="#strict" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">strict</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -166,7 +166,7 @@ Defaults to false.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.strict</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L112">packages/access-token-jwt/src/jwt-verifier.ts:112</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L112">packages/access-token-jwt/src/jwt-verifier.ts:112</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="timeoutDuration" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>timeout<wbr/>Duration</span><a href="#timeoutDuration" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">timeout<wbr/>Duration</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -176,7 +176,7 @@ Default is 5000.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.timeoutDuration</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L62">packages/access-token-jwt/src/jwt-verifier.ts:62</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L62">packages/access-token-jwt/src/jwt-verifier.ts:62</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="tokenSigningAlg" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>token<wbr/>Signing<wbr/>Alg</span><a href="#tokenSigningAlg" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">token<wbr/>Signing<wbr/>Alg</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -188,7 +188,7 @@ PS512, ES256, ES256K, ES384, ES512 or EdDSA (case-sensitive).</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.tokenSigningAlg</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L127">packages/access-token-jwt/src/jwt-verifier.ts:127</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L127">packages/access-token-jwt/src/jwt-verifier.ts:127</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-is-inherited"><a id="validators" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>validators</span><a href="#validators" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">validators</span><span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type ">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type ">Validators</span><span class="tsd-signature-symbol">&gt;</span></div>
@@ -199,7 +199,7 @@ standard claims or add new validation behavior on custom claims.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from JwtVerifierOptions.validators</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L92">packages/access-token-jwt/src/jwt-verifier.ts:92</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L92">packages/access-token-jwt/src/jwt-verifier.ts:92</a></li></ul></aside></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/interfaces/AuthResult.html
+++ b/docs/interfaces/AuthResult.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">AuthResult</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L130">packages/access-token-jwt/src/jwt-verifier.ts:130</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L130">packages/access-token-jwt/src/jwt-verifier.ts:130</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -40,21 +40,21 @@
 <div class="tsd-comment tsd-typography"><p>The Access Token JWT header.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L134">packages/access-token-jwt/src/jwt-verifier.ts:134</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L134">packages/access-token-jwt/src/jwt-verifier.ts:134</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="payload" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>payload</span><a href="#payload" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">payload</span><span class="tsd-signature-symbol">:</span> <a href="JWTPayload.html" class="tsd-signature-type tsd-kind-interface">JWTPayload</a></div>
 <div class="tsd-comment tsd-typography"><p>The Access Token JWT payload.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L138">packages/access-token-jwt/src/jwt-verifier.ts:138</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L138">packages/access-token-jwt/src/jwt-verifier.ts:138</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member"><a id="token" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>token</span><a href="#token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature"><span class="tsd-kind-property">token</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The raw Access Token JWT</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/jwt-verifier.ts#L142">packages/access-token-jwt/src/jwt-verifier.ts:142</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/jwt-verifier.ts#L142">packages/access-token-jwt/src/jwt-verifier.ts:142</a></li></ul></aside></section></section></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/docs/types/JSONPrimitive.html
+++ b/docs/types/JSONPrimitive.html
@@ -17,7 +17,7 @@
 <h1>Type alias JSONPrimitive</h1></div>
 <div class="tsd-signature"><span class="tsd-kind-type-alias">JSONPrimitive</span><span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/993c1e2/packages/access-token-jwt/src/claim-check.ts#L8">packages/access-token-jwt/src/claim-check.ts:8</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/node-oauth2-jwt-bearer/blob/814e792/packages/access-token-jwt/src/claim-check.ts#L8">packages/access-token-jwt/src/claim-check.ts:8</a></li></ul></aside></div>
 <div class="col-sidebar">
 <div class="page-menu">
 <div class="tsd-navigation settings">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8812,7 +8812,7 @@
       }
     },
     "packages/express-oauth2-jwt-bearer": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.13.1"

--- a/packages/express-oauth2-jwt-bearer/CHANGELOG.md
+++ b/packages/express-oauth2-jwt-bearer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [FOOBAR-v1.6.1](https://github.com/auth0/node-oauth2-jwt-bearer/tree/FOOBAR-v1.6.1) (2023-11-08)
+[Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.6.0...FOOBAR-v1.6.1)
+
+**Fixed**
+- chore: Remove obsolete CircleCI config [\#123](https://github.com/auth0/node-oauth2-jwt-bearer/pull/123) ([evansims](https://github.com/evansims))
+- Bump actions/setup-node from 3 to 4 [\#122](https://github.com/auth0/node-oauth2-jwt-bearer/pull/122) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump @babel/traverse from 7.21.3 to 7.23.2 [\#120](https://github.com/auth0/node-oauth2-jwt-bearer/pull/120) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [v1.6.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.6.0) (2023-10-09)
 [Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.5.0...v1.6.0)
 

--- a/packages/express-oauth2-jwt-bearer/package.json
+++ b/packages/express-oauth2-jwt-bearer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-oauth2-jwt-bearer",
   "description": "Authentication middleware for Express.js that validates JWT bearer access tokens.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "auth0/node-oauth2-jwt-bearer",


### PR DESCRIPTION

**Fixed**
- chore: Remove obsolete CircleCI config [\#123](https://github.com/auth0/node-oauth2-jwt-bearer/pull/123) ([evansims](https://github.com/evansims))
- Bump actions/setup-node from 3 to 4 [\#122](https://github.com/auth0/node-oauth2-jwt-bearer/pull/122) ([dependabot[bot]](https://github.com/apps/dependabot))
- Bump @babel/traverse from 7.21.3 to 7.23.2 [\#120](https://github.com/auth0/node-oauth2-jwt-bearer/pull/120) ([dependabot[bot]](https://github.com/apps/dependabot))
