### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## [v1.6.1](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.6.1) (2025-03-10)
+
+**Added**
+- Add support for node 22.1.0 [\#167](https://github.com/auth0/node-oauth2-jwt-bearer/pull/167) ([nandan-bhat](https://github.com/nandan-bhat))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-jwt-bearer",
-  "version": "0.0.1",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-jwt-bearer",
-      "version": "0.0.1",
+      "version": "1.6.1",
       "license": "MIT",
       "workspaces": [
         "packages/oauth2-bearer",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "author": "Auth0 <support@auth0.com>",
-  "version": "0.0.1",
+  "version": "1.6.1",
   "workspaces": [
     "packages/oauth2-bearer",
     "packages/access-token-jwt",


### PR DESCRIPTION

**Added**
- Add support for node 22.1.0 [\#167](https://github.com/auth0/node-oauth2-jwt-bearer/pull/167) ([nandan-bhat](https://github.com/nandan-bhat))
