### PR TITLE
Add support for direct public key JWT verification without JWKS disco…

### DIFF
--- a/packages/access-token-jwt/README.md
+++ b/packages/access-token-jwt/README.md
@@ -3,3 +3,11 @@
 _This package is not published_
 
 Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12)
+
+## Features
+
+- JWT verification with JWKS discovery
+- Support for direct public key verification (no JWKS required)
+- Symmetric algorithm support (HS256, HS384, HS512)
+- Asymmetric algorithm support (RS256, RS384, etc.)
+- Customizable claim validation

--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 import { jwtVerify } from 'jose';
-import type { JWTPayload, JWSHeaderParameters } from 'jose';
+import type { JWTPayload, JWSHeaderParameters, KeyLike } from 'jose';
 import { InvalidTokenError } from 'oauth2-bearer';
 import discovery from './discovery';
 import getKeyFn from './get-key-fn';
@@ -115,7 +115,7 @@ export interface JwtVerifierOptions {
    * Secret to verify an Access Token JWT signed with a symmetric algorithm.
    * By default this SDK validates tokens signed with asymmetric algorithms.
    */
-  secret?: string;
+  secret?: string | KeyLike;
 
   /**
    * You must provide this if your tokens are signed with symmetric algorithms
@@ -187,8 +187,9 @@ const jwtVerifier = ({
     "You must not provide both a 'secret' and 'jwksUri'"
   );
   assert(audience, "An 'audience' is required to validate the 'aud' claim");
+  // Only require tokenSigningAlg for string secrets (symmetric keys)
   assert(
-    !secret || (secret && tokenSigningAlg),
+    !secret || typeof secret !== 'string' || (typeof secret === 'string' && tokenSigningAlg),
     "You must provide a 'tokenSigningAlg' for validating symmetric algorithms"
   );
   assert(
@@ -198,7 +199,7 @@ const jwtVerifier = ({
     )} for 'tokenSigningAlg' to validate asymmetrically signed tokens`
   );
   assert(
-    !secret || (tokenSigningAlg && SYMMETRIC_ALGS.includes(tokenSigningAlg)),
+    !secret || typeof secret !== 'string' || (tokenSigningAlg && SYMMETRIC_ALGS.includes(tokenSigningAlg)),
     `You must supply one of ${SYMMETRIC_ALGS.join(
       ', '
     )} for 'tokenSigningAlg' to validate symmetrically signed tokens`

--- a/packages/access-token-jwt/test/public-key.test.ts
+++ b/packages/access-token-jwt/test/public-key.test.ts
@@ -1,0 +1,76 @@
+import { exportJWK, generateKeyPair } from 'jose';
+import nock from 'nock';
+import { jwtVerifier } from '../src';
+import { createJwt } from './helpers';
+
+describe('public-key verification', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should verify a token with a directly provided public key', async () => {
+    // Generate a key pair for testing
+    const { publicKey, privateKey } = await generateKeyPair('RS256');
+    
+    // Create a JWT signed with the private key
+    const tokenPayload = { foo: 'bar' };
+    const jwt = await createJwt({
+      payload: tokenPayload,
+      privateKey: privateKey
+    });
+
+    // Verify the JWT using the public key directly
+    const verify = jwtVerifier({
+      issuer: 'https://issuer.example.com/',
+      audience: 'https://api/',
+      secret: publicKey
+    });
+    
+    const result = await verify(jwt);
+    expect(result.payload.foo).toBe('bar');
+  });
+
+  it('should verify a token with directly provided public key when tokenSigningAlg is specified', async () => {
+    // Generate a key pair for testing
+    const { publicKey, privateKey } = await generateKeyPair('RS256');
+    
+    // Create a JWT signed with the private key
+    const tokenPayload = { foo: 'bar' };
+    const jwt = await createJwt({
+      payload: tokenPayload,
+      privateKey: privateKey
+    });
+
+    // Verify the JWT using the public key directly with explicit alg
+    const verify = jwtVerifier({
+      issuer: 'https://issuer.example.com/',
+      audience: 'https://api/',
+      secret: publicKey,
+      tokenSigningAlg: 'RS256'
+    });
+    
+    const result = await verify(jwt);
+    expect(result.payload.foo).toBe('bar');
+  });
+
+  it('should fail to verify when using mismatched keys', async () => {
+    // Generate two different key pairs
+    const keyPair1 = await generateKeyPair('RS256');
+    const keyPair2 = await generateKeyPair('RS256');
+    
+    // Create JWT with first private key
+    const jwt = await createJwt({
+      payload: { test: 'data' },
+      privateKey: keyPair1.privateKey
+    });
+
+    // Try to verify with second key's public key (should fail)
+    const verify = jwtVerifier({
+      issuer: 'https://issuer.example.com/',
+      audience: 'https://api/',
+      secret: keyPair2.publicKey
+    });
+    
+    await expect(verify(jwt)).rejects.toThrow();
+  });
+});

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -72,6 +72,30 @@ app.use(
 );
 ```
 
+#### Using direct public key verification (without JWKS)
+
+If you already have the public key for verifying tokens and want to bypass JWKS discovery:
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+const fs = require('fs');
+const { createPublicKey } = require('crypto');
+
+// Load your public key (this is just an example)
+const publicKeyData = fs.readFileSync('./public-key.pem');
+const publicKey = createPublicKey(publicKeyData);
+
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    secret: publicKey
+  })
+);
+```
+
+This approach allows you to verify tokens without requiring internet access to a JWKS endpoint.
+
 With this configuration, your api will require a valid Access Token JWT bearer token for all routes.
 
 Successful requests will have the following properties added to them:

--- a/packages/express-oauth2-jwt-bearer/examples/direct-public-key.md
+++ b/packages/express-oauth2-jwt-bearer/examples/direct-public-key.md
@@ -1,0 +1,30 @@
+# Direct Public Key Verification Example
+
+Below is an example of how to use the library to verify JWTs with a directly provided public key (no JWKS or discovery):
+
+```js
+const { jwtVerifier } = require('access-token-jwt');
+// or: import { jwtVerifier } from 'access-token-jwt';
+
+// You could load your public key from a file, environment variable, etc.
+// This is just an example of how you'd use it once you have the key
+// (could be a CryptoKey, KeyObject, etc.)
+const publicKey = getPublicKeyFromSomewhere();
+
+// Set up the verifier with the public key
+const verify = jwtVerifier({
+  issuer: 'https://your-issuer.example.com/',
+  audience: 'https://your-api/',
+  secret: publicKey  // Pass the public key directly
+});
+
+// Verify a token
+try {
+  const { payload, header } = await verify(token);
+  console.log('Token verified!', payload);
+} catch (err) {
+  console.error('Token verification failed:', err.message);
+}
+```
+
+With this approach you can bypass JWKS discovery and validation while still properly verifying tokens signed with asymmetric algorithms.


### PR DESCRIPTION
…very

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds support for directly providing a public key for JWT verification without requiring JWKS discovery or endpoints.

Currently, the library only supports:

1. Using `issuerBaseURL` to fetch JWKS
2. Manually providing `jwksUri` and `issuer`

This change extends the `secret` parameter to accept either:

- A string (for symmetric algorithms like HS256)
- A KeyLike object (for asymmetric algorithms like RS256)

This helps in scenarios where the public key is already known, like in air-gapped environments or custom key management systems.

### References

- Fixes #133

### Testing

Tested with:
- Direct public key verification using RSA keys
- Verification with explicit algorithms
- Negative tests with mismatched keys

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
