### PR TITLE
Make audience checking optional in JWT verification as per RFC7519 4.1.3

### DIFF
--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -22,7 +22,9 @@ export interface JwtVerifierOptions {
 
   /**
    * Expected JWT "aud" (Audience) Claim value(s).
-   * REQUIRED: You can also provide the `AUDIENCE` environment variable.
+   * Optional: You can also provide the `AUDIENCE` environment variable.
+   * If not provided, no audience validation will be performed, which aligns with RFC7519 section 4.1.3 
+   * where the "aud" claim is optional.
    */
   audience?: string | string[];
 
@@ -186,7 +188,6 @@ const jwtVerifier = ({
     !(secret && jwksUri),
     "You must not provide both a 'secret' and 'jwksUri'"
   );
-  assert(audience, "An 'audience' is required to validate the 'aud' claim");
   assert(
     !secret || (secret && tokenSigningAlg),
     "You must provide a 'tokenSigningAlg' for validating symmetric algorithms"

--- a/packages/access-token-jwt/src/validate.ts
+++ b/packages/access-token-jwt/src/validate.ts
@@ -73,6 +73,16 @@ export const defaultValidators = (
       typ.toLowerCase().replace(/^application\//, '') === 'at+jwt'),
   iss: (iss) => iss === issuer,
   aud: (aud) => {
+    // If no audience is specified in configuration, skip validation (as per RFC7519 section 4.1.3)
+    if (!audience) {
+      return true;
+    }
+    
+    // If audience is specified but not present in token, fail validation
+    if (aud === undefined) {
+      return false;
+    }
+    
     audience = typeof audience === 'string' ? [audience] : audience;
     if (typeof aud === 'string') {
       return audience.includes(aud);

--- a/packages/access-token-jwt/test/validate.test.ts
+++ b/packages/access-token-jwt/test/validate.test.ts
@@ -207,6 +207,26 @@ describe('validate', () => {
       )
     ).resolves.not.toThrow();
   });
+  
+  it('should accept missing aud claim when no audience is configured', async () => {
+    await expect(
+      validate(
+        { ...payload, aud: undefined },
+        header,
+        validators({ audience: undefined })
+      )
+    ).resolves.not.toThrow();
+  });
+  
+  it('should reject missing aud claim when audience is configured', async () => {
+    await expect(
+      validate(
+        { ...payload, aud: undefined },
+        header,
+        validators({ audience: 'foo' })
+      )
+    ).rejects.toThrow(`Unexpected 'aud' value`);
+  });
   it('should throw for invalid exp claim', async () => {
     const clock = sinon.useFakeTimers(100 * 1000);
     await expect(

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -64,8 +64,9 @@ declare global {
  * }));
  * ```
  *
- * You must provide the `audience` argument (or `AUDIENCE` environment variable)
- * used to match against the Access Token's `aud` claim.
+ * You can optionally provide the `audience` argument (or `AUDIENCE` environment variable)
+ * used to match against the Access Token's `aud` claim. If not provided, audience validation
+ * will be skipped which aligns with RFC7519 section 4.1.3 where the "aud" claim is optional.
  *
  * Successful requests will have the following properties added to them:
  *

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -126,9 +126,8 @@ describe('index', () => {
     process.env = Object.assign({}, env, {
       ISSUER_BASE_URL: 'foo',
     });
-    expect(auth).toThrow(
-      "An 'audience' is required to validate the 'aud' claim"
-    );
+    // No longer requiring audience since we made it optional
+    expect(auth).not.toThrow();
     process.env = Object.assign({}, env, {
       ISSUER_BASE_URL: 'foo',
       AUDIENCE: 'baz',


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR makes the audience claim validation optional in JWT verification. When no audience is configured, tokens without an audience claim will be accepted, following the RFC7519 section 4.1.3 specification which states the "aud" (audience) claim is optional.

**Changes**

- Removed assertion requiring audience parameter in JwtVerifierOptions
- Updated audience validation logic to skip validation when no audience is provided
- Added proper documentation explaining the optional nature of audience validation
- Updated tests to verify correct behavior with and without audience

### References

#144 

### Testing

- Added test case for missing audience claim when no audience is specified
- Added test case to verify tokens without audience are rejected when audience is configured
- Verified existing tests pass with these changes
- Manually tested token validation with and without audience claims
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
