### PR TITLE
Update CI to run against Node 20, 22 and 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 24
   CACHE_KEY: "${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}"
 
 jobs:
@@ -26,13 +26,17 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: ['20', '22', '24']
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/build
         with:
-          node: ${{ env.NODE_VERSION }}
+          node: ${{ matrix.node-version }}
 
       - name: Save build artifacts
         uses: actions/cache/save@v4
@@ -46,12 +50,16 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: ['20', '22', '24']
+
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - uses: actions/cache/restore@v4


### PR DESCRIPTION
In the light of adding [support for Node 24](https://github.com/auth0/node-oauth2-jwt-bearer/issues/182), we want to ensure we run CI on every supported version of node.