### PR TITLE
fix: fix broken link on README.md

### DIFF
--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -97,7 +97,7 @@ To learn how to:
 - Disable DPoP entirely
 - Configure proof timing with `iatOffset` and `iatLeeway`
 
-**See [DPoP examples in `EXAMPLES.md`](./EXAMPLES.md#dpop-authentication-early-access)**
+**See [DPoP examples in `EXAMPLES.md`](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/EXAMPLES.md)**
 
 
 ### Security Headers


### PR DESCRIPTION
### Changes

Link to `EXAMPLES.md` was not working on NPM page. It was working only from `README.md`. This issue is fixed in this commit.