### PR TITLE
Fix failing GH actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write # For publishing to npm using --provenance
 
 jobs:


### PR DESCRIPTION
### Changes
- Currently the GH workflow is failing after `npm publish`. This PR is to test the workflow.