### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+## [v1.8.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.8.0) (2026-04-09)
+
+**Added**
+- feat: Add Multiple Custom Domains (MCD) support [\#218](https://github.com/auth0/node-oauth2-jwt-bearer/pull/218) ([ankita10119](https://github.com/ankita10119))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oauth2-jwt-bearer",
-  "version": "0.0.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oauth2-jwt-bearer",
-      "version": "0.0.1",
+      "version": "1.8.0",
       "license": "MIT",
       "workspaces": [
         "packages/oauth2-bearer",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "author": "Auth0 <support@auth0.com>",
-  "version": "0.0.1",
+  "version": "1.8.0",
   "workspaces": [
     "packages/oauth2-bearer",
     "packages/access-token-jwt",


### PR DESCRIPTION

**Added**
- feat: Add Multiple Custom Domains (MCD) support [\#218](https://github.com/auth0/node-oauth2-jwt-bearer/pull/218) ([ankita10119](https://github.com/ankita10119))
