### PR TITLE
refactor: rename auth0MCD to mcd and update tenant terminology

### DIFF
--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -14,7 +14,7 @@ export {
   VerifyJwtResult,
   JWTPayload,
   JWSHeaderParameters as JWTHeader,
-  Auth0MCDOptions,
+  MCDOptions,
   AsymmetricIssuerConfig,
   SymmetricIssuerConfig,
   IssuerConfig,

--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -35,7 +35,7 @@ export type IssuerResolverFunction = (
   context: IssuerResolverContext
 ) => Promise<IssuerResolverResult> | IssuerResolverResult;
 
-export interface Auth0MCDOptions {
+export interface MCDOptions {
   issuers: string | string[] | IssuerConfig[] | IssuerResolverFunction;
 }
 
@@ -221,7 +221,7 @@ export interface JwtVerifierOptions {
    *
    * Cannot be used with issuerBaseURL.
    */
-  auth0MCD?: Auth0MCDOptions;
+  mcd?: MCDOptions;
 }
 
 export interface VerifyJwtResult {
@@ -266,7 +266,7 @@ const jwtVerifier = ({
   audience = process.env.AUDIENCE as string,
   secret = process.env.SECRET as string,
   tokenSigningAlg = process.env.TOKEN_SIGNING_ALG as string,
-  auth0MCD,
+  mcd,
   agent,
   cooldownDuration = 30000,
   timeoutDuration = 5000,
@@ -280,28 +280,28 @@ const jwtVerifier = ({
 
   // Validation: Ensure proper configuration
   assert(
-    auth0MCD || issuerBaseURL || (issuer && (jwksUri || secret)),
-    "You must provide 'auth0MCD', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+    mcd || issuerBaseURL || (issuer && (jwksUri || secret)),
+    "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
   );
   assert(
-    !(auth0MCD && issuerBaseURL),
-    "You must not provide both 'auth0MCD' and 'issuerBaseURL'"
+    !(mcd && issuerBaseURL),
+    "You must not provide both 'mcd' and 'issuerBaseURL'"
   );
   assert(
-    !(auth0MCD && issuer),
-    "You must not provide both 'auth0MCD' and 'issuer'. Use 'auth0MCD' for multi-issuer mode."
+    !(mcd && issuer),
+    "You must not provide both 'mcd' and 'issuer'. Use 'mcd' for multi-issuer mode."
   );
   assert(
-    !(auth0MCD && jwksUri),
-    "You must not provide both 'auth0MCD' and 'jwksUri'. Use 'auth0MCD' for multi-issuer mode."
+    !(mcd && jwksUri),
+    "You must not provide both 'mcd' and 'jwksUri'. Use 'mcd' for multi-issuer mode."
   );
   assert(
     !(secret && jwksUri),
     "You must not provide both a 'secret' and 'jwksUri'"
   );
   assert(
-    !(auth0MCD && secret),
-    'Cannot use top-level "secret" with auth0MCD mode. ' +
+    !(mcd && secret),
+    'Cannot use top-level "secret" with mcd mode. ' +
     'Specify secrets per-issuer in the issuer configuration: ' +
     '{ issuer: "...", secret: "...", alg: "HS256" }'
   );
@@ -386,15 +386,15 @@ const jwtVerifier = ({
     return { ...config, issuer: normalizeIssuerUrl(config.issuer) };
   };
 
-  // MCD Support: Validate auth0MCD configuration
-  if (auth0MCD) {
-    assert(auth0MCD.issuers, "Invalid MCD configuration: 'issuers' is required");
+  // MCD Support: Validate mcd configuration
+  if (mcd) {
+    assert(mcd.issuers, "Invalid MCD configuration: 'issuers' is required");
 
     // Validate static issuer configurations at initialization
-    if (typeof auth0MCD.issuers !== 'function') {
-      const staticIssuers = Array.isArray(auth0MCD.issuers)
-        ? auth0MCD.issuers
-        : [auth0MCD.issuers];
+    if (typeof mcd.issuers !== 'function') {
+      const staticIssuers = Array.isArray(mcd.issuers)
+        ? mcd.issuers
+        : [mcd.issuers];
 
       staticIssuers.forEach((issuerConfig) => {
         // Normalize and validate URL (this will throw errors for security issues)
@@ -558,7 +558,7 @@ const jwtVerifier = ({
 
     try {
       // MCD Mode: Handle multiple issuers
-      if (auth0MCD) {
+      if (mcd) {
         // STEP 1: Decode token (unverified) to extract issuer claim and algorithm
         const unverifiedPayload = decodeJwt(jwt);
         const tokenIssuer = unverifiedPayload.iss;
@@ -572,7 +572,7 @@ const jwtVerifier = ({
         // STEP 2: Resolve issuers (static or dynamic)
         let resolvedIssuers: (string | IssuerConfig)[];
 
-        if (typeof auth0MCD.issuers === 'function') {
+        if (typeof mcd.issuers === 'function') {
           // Dynamic resolver with real request context
           const context: IssuerResolverContext = {
             url: requestContext?.url
@@ -580,17 +580,17 @@ const jwtVerifier = ({
               : new URL('http://localhost'),
             headers: requestContext?.headers || {},
           };
-          const result = await auth0MCD.issuers(context);
-          
+          const result = await mcd.issuers(context);
+
           if (!Array.isArray(result)) {
             throw new InvalidRequestError('Issuer resolver function must return an array');
           }
-          
+
           resolvedIssuers = result;
         } else {
-          resolvedIssuers = Array.isArray(auth0MCD.issuers)
-            ? auth0MCD.issuers
-            : [auth0MCD.issuers];
+          resolvedIssuers = Array.isArray(mcd.issuers)
+            ? mcd.issuers
+            : [mcd.issuers];
         }
 
         if (resolvedIssuers.length === 0) {

--- a/packages/access-token-jwt/test/jwt-verifier.test.ts
+++ b/packages/access-token-jwt/test/jwt-verifier.test.ts
@@ -14,7 +14,7 @@ describe('jwt-verifier', () => {
         audience: 'https://api/',
       })
     ).toThrowError(
-      "You must provide 'auth0MCD', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
     );
   });
 
@@ -353,33 +353,33 @@ describe('jwt-verifier', () => {
 
   // MCD Tests
   describe('MCD (Multiple Custom Domains)', () => {
-    it('should throw when both auth0MCD and issuerBaseURL are provided', () => {
+    it('should throw when both mcd and issuerBaseURL are provided', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: ['https://tenant1.auth0.com'],
           },
           issuerBaseURL: 'https://tenant1.auth0.com',
           audience: 'https://api/',
         })
       ).toThrowError(
-        "You must not provide both 'auth0MCD' and 'issuerBaseURL'"
+        "You must not provide both 'mcd' and 'issuerBaseURL'"
       );
     });
 
-    it('should throw when auth0MCD is provided without issuers', () => {
+    it('should throw when mcd is provided without issuers', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {} as any,
+          mcd: {} as any,
           audience: 'https://api/',
         })
       ).toThrowError("Invalid MCD configuration: 'issuers' is required");
     });
 
-    it('should throw when both auth0MCD and issuer are provided', () => {
+    it('should throw when both mcd and issuer are provided', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: ['https://tenant1.auth0.com'],
           },
           issuer: 'https://tenant1.auth0.com',
@@ -387,35 +387,35 @@ describe('jwt-verifier', () => {
           audience: 'https://api/',
         })
       ).toThrowError(
-        "You must not provide both 'auth0MCD' and 'issuer'. Use 'auth0MCD' for multi-issuer mode."
+        "You must not provide both 'mcd' and 'issuer'. Use 'mcd' for multi-issuer mode."
       );
     });
 
-    it('should throw when both auth0MCD and jwksUri are provided', () => {
+    it('should throw when both mcd and jwksUri are provided', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: ['https://tenant1.auth0.com'],
           },
           jwksUri: 'https://tenant1.auth0.com/.well-known/jwks.json',
           audience: 'https://api/',
         })
       ).toThrowError(
-        "You must not provide both 'auth0MCD' and 'jwksUri'. Use 'auth0MCD' for multi-issuer mode."
+        "You must not provide both 'mcd' and 'jwksUri'. Use 'mcd' for multi-issuer mode."
       );
     });
 
-    it('should throw when both auth0MCD and secret are provided', () => {
+    it('should throw when both mcd and secret are provided', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: ['https://tenant1.auth0.com'],
           },
           secret: 'my-secret',
           audience: 'https://api/',
         })
       ).toThrowError(
-        'Cannot use top-level "secret" with auth0MCD mode. ' +
+        'Cannot use top-level "secret" with mcd mode. ' +
         'Specify secrets per-issuer in the issuer configuration: ' +
         '{ issuer: "...", secret: "...", alg: "HS256" }'
       );
@@ -425,7 +425,7 @@ describe('jwt-verifier', () => {
     it('should throw at init when symmetric algorithm configured without secret', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: [
               {
                 issuer: 'https://tenant1.auth0.com',
@@ -444,7 +444,7 @@ describe('jwt-verifier', () => {
     it('should throw at init when secret provided with asymmetric algorithm', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: [
               {
                 issuer: 'https://tenant1.auth0.com',
@@ -463,7 +463,7 @@ describe('jwt-verifier', () => {
     it('should throw at init when secret provided without algorithm', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: [
               {
                 issuer: 'https://tenant1.auth0.com',
@@ -481,7 +481,7 @@ describe('jwt-verifier', () => {
     it('should not throw when string-only issuer configs used (no algorithm specified)', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: ['https://tenant1.auth0.com', 'https://tenant2.auth0.com'],
           },
           audience: 'https://api/',
@@ -492,7 +492,7 @@ describe('jwt-verifier', () => {
     it('should not throw when valid symmetric config provided', () => {
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: [
               {
                 issuer: 'https://tenant1.auth0.com',
@@ -511,7 +511,7 @@ describe('jwt-verifier', () => {
       // Should not throw at initialization
       expect(() =>
         jwtVerifier({
-          auth0MCD: {
+          mcd: {
             issuers: async () => {
               // Could return invalid config at runtime, but we can't check now
               return [
@@ -536,7 +536,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -559,7 +559,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             'https://tenant1.example.com/',
             'https://tenant2.example.com/',
@@ -580,7 +580,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -601,7 +601,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -623,7 +623,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -644,7 +644,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             'https://tenant1.example.com/',
             'https://tenant2.example.com/',
@@ -670,7 +670,7 @@ describe('jwt-verifier', () => {
         .sign(privateKey);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -691,7 +691,7 @@ describe('jwt-verifier', () => {
 
       // Config with normalized URL
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com'],
         },
         audience: 'https://api/',
@@ -708,7 +708,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async (context) => {
             // Dynamic resolver that returns allowed issuers as strings (currently supported)
             return ['https://tenant1.example.com/', 'https://tenant2.example.com/'];
@@ -728,7 +728,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async (context) => {
             return ['https://tenant1.example.com/'];
           },
@@ -751,7 +751,7 @@ describe('jwt-verifier', () => {
       const fakeJwt = `${header}.${payload}.fake-signature`;
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => [], // Returns empty array
         },
         audience: 'https://api/',
@@ -774,7 +774,7 @@ describe('jwt-verifier', () => {
       const fakeJwt = `${header}.${payload}.`; // No signature for "none" alg
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -792,7 +792,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -818,7 +818,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -841,7 +841,7 @@ describe('jwt-verifier', () => {
       const malformedJwt = '!!!notbase64!!!.payload.signature';
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -865,7 +865,7 @@ describe('jwt-verifier', () => {
       const fakeJwt = `${headerWithoutAlg}.${payload}.fake-signature`;
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -884,7 +884,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async (context) => {
             return [
               {
@@ -911,7 +911,7 @@ describe('jwt-verifier', () => {
       const resolverSpy = jest.fn().mockResolvedValue(['https://tenant1.example.com/']);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: resolverSpy,
         },
         audience: 'https://api/',
@@ -935,7 +935,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             'https://tenant1.example.com/',
             {
@@ -966,7 +966,7 @@ describe('jwt-verifier', () => {
         .reply(404);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -987,7 +987,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com:8443'],
         },
         audience: 'https://api/',
@@ -1004,7 +1004,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['http://tenant1.example.com:8080'],
         },
         audience: 'https://api/',
@@ -1021,7 +1021,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: 'https://tenant1.example.com/', // Single string, not array
         },
         audience: 'https://api/',
@@ -1038,7 +1038,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/auth/tenant1'],
         },
         audience: 'https://api/',
@@ -1056,7 +1056,7 @@ describe('jwt-verifier', () => {
       // Use a resolver that returns a malformed URL
       // The normalization catch block will return it as-is
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => {
             // This will trigger the catch block in normalizeIssuerUrl
             // because it's not a valid URL format
@@ -1081,7 +1081,7 @@ describe('jwt-verifier', () => {
 
       // Config WITHOUT protocol
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['tenant1.example.com'], // No https://
         },
         audience: 'https://api/',
@@ -1100,7 +1100,7 @@ describe('jwt-verifier', () => {
 
       // Config WITHOUT protocol but WITH trailing slash
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['tenant1.example.com/'], // No https:// but has /
         },
         audience: 'https://api/',
@@ -1126,7 +1126,7 @@ describe('jwt-verifier', () => {
         .reply(404);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -1157,7 +1157,7 @@ describe('jwt-verifier', () => {
         });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -1181,7 +1181,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: [
             {
               issuer: 'https://tenant1.example.com/',
@@ -1212,7 +1212,7 @@ describe('jwt-verifier', () => {
         });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: ['https://tenant1.example.com/'],
         },
         audience: 'https://api/',
@@ -1233,7 +1233,7 @@ describe('jwt-verifier', () => {
       const resolverSpy = jest.fn().mockResolvedValue(['https://tenant1.example.com/']);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: resolverSpy,
         },
         audience: 'https://api/',
@@ -1261,7 +1261,7 @@ describe('jwt-verifier', () => {
       const resolverSpy = jest.fn().mockResolvedValue(['https://tenant1.example.com/']);
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: resolverSpy,
         },
         audience: 'https://api/',
@@ -1292,7 +1292,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => 'not-an-array' as any, // Returns string instead of array
         },
         audience: 'https://api/',
@@ -1311,7 +1311,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => ['https://tenant1.example.com/'], // String arrays still supported
         },
         audience: 'https://api/',
@@ -1328,7 +1328,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => [
             { issuer: 'https://tenant1.example.com/', alg: 'HS256' }, // no secret
           ],
@@ -1349,7 +1349,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => [
             { issuer: 'https://tenant1.example.com/', alg: 'RS256', secret },
           ],
@@ -1370,7 +1370,7 @@ describe('jwt-verifier', () => {
       });
 
       const verify = jwtVerifier({
-        auth0MCD: {
+        mcd: {
           issuers: async () => [
             { issuer: 'https://tenant1.example.com/', secret } as any, // no alg
           ],
@@ -1396,7 +1396,7 @@ describe('jwt-verifier', () => {
       it('should throw error for userinfo in issuer URL', () => {
         expect(() => {
           jwtVerifier({
-            auth0MCD: {
+            mcd: {
               issuers: ['https://user:pass@tenant1.example.com/'],
             },
             audience: 'https://api/',
@@ -1407,7 +1407,7 @@ describe('jwt-verifier', () => {
       it('should throw error for query parameters in issuer URL', () => {
         expect(() => {
           jwtVerifier({
-            auth0MCD: {
+            mcd: {
               issuers: ['https://tenant1.example.com/?debug=true&env=test'],
             },
             audience: 'https://api/',
@@ -1418,7 +1418,7 @@ describe('jwt-verifier', () => {
       it('should throw error for URL fragments in issuer URL', () => {
         expect(() => {
           jwtVerifier({
-            auth0MCD: {
+            mcd: {
               issuers: ['https://tenant1.example.com/#section'],
             },
             audience: 'https://api/',
@@ -1433,7 +1433,7 @@ describe('jwt-verifier', () => {
         try {
           expect(() => {
             jwtVerifier({
-              auth0MCD: {
+              mcd: {
                 issuers: ['http://tenant1.example.com:8080/'],
               },
               audience: 'https://api/',
@@ -1454,7 +1454,7 @@ describe('jwt-verifier', () => {
           });
 
           const verify = jwtVerifier({
-            auth0MCD: {
+            mcd: {
               issuers: ['http://tenant1.example.com:8080/'],
             },
             audience: 'https://api/',
@@ -1470,7 +1470,7 @@ describe('jwt-verifier', () => {
       it('should throw error for multiple security issues in same URL', () => {
         expect(() => {
           jwtVerifier({
-            auth0MCD: {
+            mcd: {
               issuers: ['https://user:pass@tenant1.example.com/?debug=true#section'],
             },
             audience: 'https://api/',

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -267,7 +267,7 @@ app.get('/api/protected', (req, res) => {
 
 ## Multiple Custom Domains (MCD)
 
-Use `auth0MCD` to accept JWT tokens from multiple custom domains belonging to the **same Auth0 tenant**. `auth0MCD` and `issuerBaseURL` are mutually exclusive — use one or the other.
+Use `mcd` to accept JWT tokens from multiple custom domains belonging to the **same Authorization Server**. `mcd` and `issuerBaseURL` are mutually exclusive — use one or the other.
 
 Common use cases:
 
@@ -275,14 +275,14 @@ Common use cases:
 - **Multiple frontend applications** — a single API serves multiple frontend apps, each with its own custom domain.
 - **Domain migration** — gradually migrating traffic from a canonical Auth0 domain to a new custom domain without breaking existing tokens.
 
-> **Note:** MCD is not a mechanism for accepting tokens from multiple Auth0 tenants. All configured issuers must belong to the same tenant.
+> **Note:** MCD is not a mechanism for accepting tokens from multiple Authorization Servers. All configured issuers must belong to the same Authorization Server.
 
 ### Security requirements
 
 - **Use an allowlist.** The resolver must return only pre-approved issuer URLs. Never construct or look up discovery/JWKS URLs dynamically from request input.
 - **Do not trust request-derived values directly.** `context.headers` and `context.url` come from the incoming request. Use them only to *select* from a hard-coded allowlist, never as URLs themselves.
 - **Ensure HTTPS.** Custom `jwksUri` values in issuer configs must use HTTPS in production.
-- **Single-tenant only.** All configured issuers must belong to the same Auth0 tenant.
+- **Single-tenant only.** All configured issuers must belong to the same Authorization Server.
 
 ### Static list of issuers
 
@@ -291,7 +291,7 @@ const { auth } = require('express-oauth2-jwt-bearer');
 
 app.use(
   auth({
-    auth0MCD: {
+    mcd: {
       issuers: [
         'https://brand-a.example.com',
         'https://brand-b.example.com',
@@ -319,7 +319,7 @@ const ALLOWED_ISSUERS = {
 
 app.use(
   auth({
-    auth0MCD: {
+    mcd: {
       issuers: async (context) => {
         // x-tenant-id must be set by trusted upstream middleware, not the client.
         const tenantId = context.headers['x-tenant-id'];
@@ -339,7 +339,7 @@ By default the SDK caches OIDC discovery metadata and JWKS responses (100 entrie
 
 ```js
 auth({
-  auth0MCD: { issuers: [...] },
+  mcd: { issuers: [...] },
   audience: 'https://your-api.com',
   cache: {
     discovery: { maxEntries: 50, ttl: 300_000 }, // 5 minutes

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -206,7 +206,7 @@ export {
   Validators,
   JWTHeader,
   JSONPrimitive,
-  Auth0MCDOptions,
+  MCDOptions,
   AsymmetricIssuerConfig,
   SymmetricIssuerConfig,
   IssuerConfig,

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -118,7 +118,7 @@ describe('index', () => {
   it('should accept empty arguments and env vars', async () => {
     const env = process.env;
     await expect(auth).toThrowError(
-      "You must provide 'auth0MCD', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
     );
     process.env = Object.assign({}, env, {
       ISSUER_BASE_URL: 'foo',


### PR DESCRIPTION
### Description

 This PR renames the auth0MCD configuration option to mcd and the Auth0MCDOptions type to MCDOptions across the SDK. It also replaces "Auth0 Tenant" with "Authorization Server" in
  documentation to use vendor-neutral, spec-aligned language consistent with RFC 6749/RFC 8414.                                                                                                 
   
  Changes:                                                                                                                                                                                      
  - **auth0MCD** option → **mcd** in JwtVerifierOptions                                                                                                                                               
  - **Auth0MCDOptions** type → **MCDOptions** (exported from both packages)
  - All error messages updated to reference **mcd** instead of **auth0MCD**
  - "**Auth0 Tenant**" → "**Authorization Server**" in EXAMPLES.md

### References

N/A

### Testing

All existing MCD unit tests have been updated to use the renamed option and updated error message strings. No new test logic was required as this is a pure rename with no behavioral change.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
