### PR TITLE
chore: rely on OIDC when publishing to npm

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -26,6 +24,10 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@11
+
     - name: Install dependencies
       shell: bash
       run: npm ci --include=dev
@@ -46,7 +48,6 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --tag $TAG
+        npm publish --tag $TAG
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -16,14 +16,15 @@ on:
     secrets:
       github-token:
         required: true
-      npm-token:
-        required: true
 
 jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       # Checkout the code
@@ -70,7 +71,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           require-build: ${{ inputs.require-build }}
           version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.npm-token }}
           release-directory: ${{ inputs.release-directory }}
 
       # Create a release for the tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,4 @@ jobs:
       require-build: true
       release-directory: "./packages/express-oauth2-jwt-bearer"
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Drop reliance on an NPM token and use **OIDC** instead for publishing SDKs by configuring **trusted publishers**.

## References

* [https://docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers)

## Testing

* This change adds test coverage for new, changed, or fixed functionality.

## Checklist

* [ ] I have added documentation for new or changed functionality in this PR or on **auth0.com/docs**
* [ ] All active GitHub checks for tests, formatting, and security are passing
* [ ] The correct base branch is being used (if not the default branch)

