### PR TITLE
feat: add publicKey option for asymmetric verification without discovery

### DIFF
--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -14,6 +14,7 @@ export {
   VerifyJwtResult,
   JWTPayload,
   JWSHeaderParameters as JWTHeader,
+  PublicKeyInput,
   MCDOptions,
   AsymmetricIssuerConfig,
   SymmetricIssuerConfig,

--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -87,7 +87,8 @@ export interface JwtVerifierOptions {
   /**
    * Url for the authorization server's JWKS to find the public key to verify
    * an Access Token JWT signed with an asymmetric algorithm.
-   * REQUIRED (if you don't include {@Link AuthOptions.issuerBaseURL})
+   * REQUIRED (if you don't include {@Link AuthOptions.issuerBaseURL} or
+   * {@Link AuthOptions.publicKey})
    * You can also provide the `JWKS_URI` environment variable.
    */
   jwksUri?: string;

--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -2,18 +2,33 @@ import { strict as assert } from 'assert';
 import { TextEncoder } from 'util';
 import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
-import { jwtVerify, decodeJwt, decodeProtectedHeader } from 'jose';
-import type { JWTPayload, JWSHeaderParameters } from 'jose';
+import { jwtVerify, decodeJwt, decodeProtectedHeader, importSPKI, importJWK, createLocalJWKSet } from 'jose';
+import type { JWTPayload, JWSHeaderParameters, JWK, JSONWebKeySet, KeyLike } from 'jose';
 import { InvalidTokenError, InvalidRequestError } from 'oauth2-bearer';
 import discovery from './discovery';
 import getKeyFn from './get-key-fn';
 import validate, { defaultValidators, Validators } from './validate';
+
+/**
+ * A static public key for asymmetric JWT verification without discovery or a
+ * remote JWKS endpoint.  Accepted forms:
+ *
+ * - `string` – PEM-encoded SPKI public key (requires `tokenSigningAlg` or `alg`)
+ * - `JWK` – a single JWK object (`{ kty, n, e, … }`)
+ * - `JSONWebKeySet` – an inline JWK Set (`{ keys: [...] }`)
+ */
+export type PublicKeyInput = string | JWK | JSONWebKeySet;
 
 // MCD Types
 export interface AsymmetricIssuerConfig {
   issuer: string;
   alg?: string;
   jwksUri?: string;
+  /**
+   * A static public key used to verify tokens from this issuer without
+   * hitting a remote JWKS endpoint.  Mutually exclusive with `jwksUri`.
+   */
+  publicKey?: PublicKeyInput;
 }
 
 export interface SymmetricIssuerConfig {
@@ -201,6 +216,31 @@ export interface JwtVerifierOptions {
   secret?: string;
 
   /**
+   * A static public key for verifying an Access Token JWT signed with an
+   * asymmetric algorithm, without requiring OIDC discovery or a remote JWKS
+   * endpoint.
+   *
+   * Accepted formats:
+   * - PEM-encoded SPKI string — requires `tokenSigningAlg`
+   * - A JWK object `{ kty, n, e, … }` — `alg` field in the JWK or
+   *   `tokenSigningAlg` must identify the algorithm
+   * - An inline JWK Set `{ keys: [...] }` — key selection uses the token's
+   *   `kid` header and each key's own `alg` field
+   *
+   * Mutually exclusive with `secret`, `jwksUri`, and `issuerBaseURL`.
+   *
+   * ```js
+   * jwtVerifier({
+   *   issuer: 'https://issuer.example.com/',
+   *   audience: 'https://api/',
+   *   publicKey: '-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----',
+   *   tokenSigningAlg: 'RS256',
+   * })
+   * ```
+   */
+  publicKey?: PublicKeyInput;
+
+  /**
    * You must provide this if your tokens are signed with symmetric algorithms
    * and it must be one of HS256, HS384 or HS512.
    * You may provide this if your tokens are signed with asymmetric algorithms
@@ -265,6 +305,7 @@ const jwtVerifier = ({
   issuer = process.env.ISSUER as string,
   audience = process.env.AUDIENCE as string,
   secret = process.env.SECRET as string,
+  publicKey,
   tokenSigningAlg = process.env.TOKEN_SIGNING_ALG as string,
   mcd,
   agent,
@@ -280,8 +321,8 @@ const jwtVerifier = ({
 
   // Validation: Ensure proper configuration
   assert(
-    mcd || issuerBaseURL || (issuer && (jwksUri || secret)),
-    "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+    mcd || issuerBaseURL || (issuer && (jwksUri || secret || publicKey)),
+    "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri', 'secret', or 'publicKey')"
   );
   assert(
     !(mcd && issuerBaseURL),
@@ -300,10 +341,28 @@ const jwtVerifier = ({
     "You must not provide both a 'secret' and 'jwksUri'"
   );
   assert(
+    !(publicKey && jwksUri),
+    "You must not provide both a 'publicKey' and 'jwksUri'"
+  );
+  assert(
+    !(publicKey && secret),
+    "You must not provide both a 'publicKey' and 'secret'"
+  );
+  assert(
+    !(publicKey && issuerBaseURL),
+    "You must not provide both a 'publicKey' and 'issuerBaseURL'"
+  );
+  assert(
     !(mcd && secret),
     'Cannot use top-level "secret" with mcd mode. ' +
     'Specify secrets per-issuer in the issuer configuration: ' +
     '{ issuer: "...", secret: "...", alg: "HS256" }'
+  );
+  assert(
+    !(mcd && publicKey),
+    'Cannot use top-level "publicKey" with mcd mode. ' +
+    'Specify publicKey per-issuer in the issuer configuration: ' +
+    '{ issuer: "...", publicKey: "..." }'
   );
   assert(audience, "An 'audience' is required to validate the 'aud' claim");
   assert(
@@ -404,7 +463,23 @@ const jwtVerifier = ({
         if (typeof issuerConfig === 'string') return;
 
         const hasSecret = 'secret' in issuerConfig && issuerConfig.secret;
+        const hasPublicKey = 'publicKey' in issuerConfig && (issuerConfig as AsymmetricIssuerConfig).publicKey;
+        const hasJwksUri = 'jwksUri' in issuerConfig && (issuerConfig as AsymmetricIssuerConfig).jwksUri;
         const configuredAlg = issuerConfig.alg;
+
+        // publicKey and jwksUri are mutually exclusive per issuer
+        if (hasPublicKey && hasJwksUri) {
+          throw new Error(
+            `Configuration error: Issuer '${issuerConfig.issuer}' provides both 'publicKey' and 'jwksUri'. These are mutually exclusive.`
+          );
+        }
+
+        // publicKey and secret are mutually exclusive per issuer
+        if (hasPublicKey && hasSecret) {
+          throw new Error(
+            `Configuration error: Issuer '${issuerConfig.issuer}' provides both 'publicKey' and 'secret'. Use 'publicKey' for asymmetric and 'secret' for symmetric verification.`
+          );
+        }
 
         // Check if symmetric algorithm configured without secret
         if (
@@ -479,6 +554,7 @@ const jwtVerifier = ({
     }
   };
 
+
   /**
    * Helper: Verify and validate JWT signature and claims
    *
@@ -492,6 +568,7 @@ const jwtVerifier = ({
    * @param issuerValue - Expected issuer for 'iss' claim validation
    * @param jwksUriValue - JWKS URI for asymmetric signature verification (RS256, ES256, etc.)
    * @param secretValue - Secret for symmetric signature verification (HS256, HS384, HS512)
+   * @param publicKeyValue - Static public key for asymmetric verification without a remote JWKS
    * @param algValue - Expected signing algorithm
    * @param allowedSigningAlgsValue - List of allowed signing algorithms from discovery
    * @returns Verified JWT payload, header, and original token
@@ -501,6 +578,7 @@ const jwtVerifier = ({
     issuerValue: string,
     jwksUriValue: string | undefined,
     secretValue: string | undefined,
+    publicKeyValue: PublicKeyInput | undefined,
     algValue: string | undefined,
     allowedSigningAlgsValue: string[] | undefined
   ): Promise<VerifyJwtResult> => {
@@ -532,8 +610,35 @@ const jwtVerifier = ({
       const result = await jwtVerify(jwt, keyFn, { clockTolerance });
       payload = result.payload;
       header = result.protectedHeader;
+    } else if (publicKeyValue) {
+      // Static public key verification (RS256, ES256, PS256, etc.)
+      // The caller supplied the public key directly — no remote fetch needed.
+      if (typeof publicKeyValue === 'string') {
+        // PEM SPKI format — algorithm must be specified explicitly
+        if (!algValue) {
+          throw new InvalidRequestError(
+            "You must provide 'tokenSigningAlg' (or 'alg' in the issuer config) when using a PEM public key"
+          );
+        }
+        const importedKey = await importSPKI(publicKeyValue, algValue);
+        const result = await jwtVerify(jwt, importedKey, { clockTolerance });
+        payload = result.payload;
+        header = result.protectedHeader;
+      } else if ('keys' in publicKeyValue) {
+        // Inline JWK Set — createLocalJWKSet handles key selection by kid/alg
+        const keySet = createLocalJWKSet(publicKeyValue as JSONWebKeySet);
+        const result = await jwtVerify(jwt, keySet, { clockTolerance });
+        payload = result.payload;
+        header = result.protectedHeader;
+      } else {
+        // Single JWK — alg comes from the JWK's own `alg` field or algValue
+        const importedKey = await importJWK(publicKeyValue as JWK, algValue) as KeyLike;
+        const result = await jwtVerify(jwt, importedKey, { clockTolerance });
+        payload = result.payload;
+        header = result.protectedHeader;
+      }
     } else if (jwksUriValue) {
-      // Asymmetric algorithm verification (RS256, ES256, PS256, etc.)
+      // Asymmetric algorithm verification via remote JWKS (RS256, ES256, PS256, etc.)
       // These use public/private key pairs. We fetch the public keys from the JWKS endpoint
       // and use them to verify the signature. The getKeyFnGetter handles JWKS caching.
       const result = await jwtVerify(jwt, getKeyFnGetter(jwksUriValue), {
@@ -543,7 +648,7 @@ const jwtVerifier = ({
       header = result.protectedHeader;
     } else {
       // This should never happen if configuration is valid, but we check defensively
-      throw new InvalidTokenError('No JWKS URI or secret available for verification');
+      throw new InvalidTokenError('No JWKS URI, public key, or secret available for verification');
     }
 
     // Validate claims: Check all JWT claims (iss, aud, exp, custom claims, etc.)
@@ -607,15 +712,26 @@ const jwtVerifier = ({
           throw new InvalidTokenError('Token issuer is not allowed');
         }
 
-        // STEP 3a: Reject symmetric algorithms if no secret configured
-        // This prevents SSRF attacks by ensuring we never fetch JWKS for symmetric tokens
-        const hasSecret = 'secret' in matchedConfig && matchedConfig.secret;
-        validateAlgorithmEarly(jwt, !!hasSecret);
-
-        // STEP 3b: Validate resolver-returned config is internally consistent.
+        // STEP 3a: Validate resolver-returned config is internally consistent.
         // Dynamic resolvers bypass the upfront static-config checks, so we apply
         // the same alg/secret consistency rules here at verification time.
+        // These checks run BEFORE validateAlgorithmEarly so that conflicts like
+        // publicKey+secret are reported with a clear error before algorithm checks.
+        const hasSecret = 'secret' in matchedConfig && matchedConfig.secret;
+        const hasPublicKey = 'publicKey' in matchedConfig &&
+          !!(matchedConfig as AsymmetricIssuerConfig).publicKey;
         const configAlg = matchedConfig.alg;
+
+        if (hasPublicKey && hasSecret) {
+          throw new InvalidTokenError(
+            `Issuer provides both 'publicKey' and 'secret'. These are mutually exclusive.`
+          );
+        }
+        if (hasPublicKey && 'jwksUri' in matchedConfig && (matchedConfig as AsymmetricIssuerConfig).jwksUri) {
+          throw new InvalidTokenError(
+            `Issuer provides both 'publicKey' and 'jwksUri'. These are mutually exclusive.`
+          );
+        }
         if (configAlg && SYMMETRIC_ALGS.includes(configAlg) && !hasSecret) {
           throw new InvalidTokenError(
             `Issuer specifies symmetric algorithm but no secret provided`
@@ -632,9 +748,14 @@ const jwtVerifier = ({
           );
         }
 
+        // STEP 3b: Reject symmetric algorithms if no secret configured
+        // This prevents SSRF attacks by ensuring we never fetch JWKS for symmetric tokens
+        validateAlgorithmEarly(jwt, !!hasSecret);
+
         // STEP 4: Get JWKS URI and configure verification
         let finalJwksUri: string | undefined;
         let finalSecret: string | undefined;
+        let finalPublicKey: PublicKeyInput | undefined;
         let finalAlg: string | undefined;
 
         if (hasSecret) {
@@ -645,7 +766,10 @@ const jwtVerifier = ({
           // Asymmetric algorithm
           finalAlg = (matchedConfig as AsymmetricIssuerConfig).alg;
 
-          if ((matchedConfig as AsymmetricIssuerConfig).jwksUri) {
+          if (hasPublicKey) {
+            // Static public key provided — no discovery or remote JWKS needed
+            finalPublicKey = (matchedConfig as AsymmetricIssuerConfig).publicKey;
+          } else if ((matchedConfig as AsymmetricIssuerConfig).jwksUri) {
             // Custom JWKS URI provided
             finalJwksUri = (matchedConfig as AsymmetricIssuerConfig).jwksUri;
           } else {
@@ -671,8 +795,8 @@ const jwtVerifier = ({
         }
 
         // STEP 5-7: Verify signature and validate claims
-        // Now that we've identified the correct issuer config and obtained the JWKS URI
-        // (or secret), we can verify the JWT signature and validate all claims.
+        // Now that we've identified the correct issuer config and obtained the JWKS URI,
+        // static public key (or secret), we can verify the JWT signature and validate all claims.
         // Note: We use the original token issuer (not normalized) for validation to
         // ensure the 'iss' claim check matches exactly what's in the token.
         return await verifyAndValidateJwt(
@@ -680,6 +804,7 @@ const jwtVerifier = ({
           tokenIssuer, // Original issuer from token (not normalized)
           finalJwksUri,
           finalSecret,
+          finalPublicKey,
           finalAlg,
           allowedSigningAlgs
         );
@@ -695,21 +820,22 @@ const jwtVerifier = ({
           issuer: discoveredIssuer,
           id_token_signing_alg_values_supported: idTokenSigningAlgValuesSupported,
         } = await getDiscovery(issuerBaseURL);
-        
+
         jwksUri = jwksUri || discoveredJwksUri;
         issuer = issuer || discoveredIssuer;
         allowedSigningAlgs = idTokenSigningAlgValuesSupported;
       }
 
       // Verify signature and validate claims for single issuer mode
-      // At this point we have everything we need: the issuer, JWKS URI (or secret),
-      // and algorithm configuration. The helper handles the actual signature verification
-      // and claim validation using the same logic as MCD mode.
+      // At this point we have everything we need: the issuer, JWKS URI, static public key
+      // (or secret), and algorithm configuration. The helper handles the actual signature
+      // verification and claim validation using the same logic as MCD mode.
       return await verifyAndValidateJwt(
         jwt,
         issuer,
         jwksUri,
         secret,
+        publicKey,
         tokenSigningAlg,
         allowedSigningAlgs
       );

--- a/packages/access-token-jwt/src/jwt-verifier.ts
+++ b/packages/access-token-jwt/src/jwt-verifier.ts
@@ -529,6 +529,15 @@ const jwtVerifier = ({
     cache,
   });
 
+  // Lazy public key import caches — key parsing is expensive; cache once per unique key.
+  // PEM strings are keyed by (pem + "\0" + alg) since the same PEM with a different
+  // algorithm would produce a different CryptoKey.
+  const _pemKeyCache = new Map<string, Promise<KeyLike>>();
+  // JWK and JWK Set objects are keyed by object identity via WeakMap so that they
+  // can be garbage-collected when the verifier itself is no longer referenced.
+  const _jwkKeyCache = new WeakMap<object, Promise<KeyLike>>();
+  const _jwkSetFnCache = new WeakMap<object, ReturnType<typeof createLocalJWKSet>>();
+
   // Helper: Early algorithm validation
   const validateAlgorithmEarly = (jwt: string, hasSecret: boolean) => {
     const { alg } = decodeProtectedHeader(jwt);
@@ -613,6 +622,8 @@ const jwtVerifier = ({
     } else if (publicKeyValue) {
       // Static public key verification (RS256, ES256, PS256, etc.)
       // The caller supplied the public key directly — no remote fetch needed.
+      // All three branches cache their result so the expensive key-import work
+      // is only performed once per unique key across all verification calls.
       if (typeof publicKeyValue === 'string') {
         // PEM SPKI format — algorithm must be specified explicitly
         if (!algValue) {
@@ -620,19 +631,41 @@ const jwtVerifier = ({
             "You must provide 'tokenSigningAlg' (or 'alg' in the issuer config) when using a PEM public key"
           );
         }
-        const importedKey = await importSPKI(publicKeyValue, algValue);
+        const cacheKey = `${publicKeyValue}\0${algValue}`;
+        if (!_pemKeyCache.has(cacheKey)) {
+          _pemKeyCache.set(cacheKey, importSPKI(publicKeyValue, algValue));
+        }
+        const importedKey = await _pemKeyCache.get(cacheKey)!;
         const result = await jwtVerify(jwt, importedKey, { clockTolerance });
         payload = result.payload;
         header = result.protectedHeader;
-      } else if ('keys' in publicKeyValue) {
-        // Inline JWK Set — createLocalJWKSet handles key selection by kid/alg
-        const keySet = createLocalJWKSet(publicKeyValue as JSONWebKeySet);
+      } else if ('keys' in publicKeyValue && Array.isArray((publicKeyValue as any).keys)) {
+        // Inline JWK Set — createLocalJWKSet handles key selection by kid/alg.
+        // createLocalJWKSet is synchronous so we cache the returned function directly.
+        if (!_jwkSetFnCache.has(publicKeyValue)) {
+          _jwkSetFnCache.set(publicKeyValue, createLocalJWKSet(publicKeyValue as JSONWebKeySet));
+        }
+        const keySet = _jwkSetFnCache.get(publicKeyValue)!;
         const result = await jwtVerify(jwt, keySet, { clockTolerance });
         payload = result.payload;
         header = result.protectedHeader;
       } else {
-        // Single JWK — alg comes from the JWK's own `alg` field or algValue
-        const importedKey = await importJWK(publicKeyValue as JWK, algValue) as KeyLike;
+        // Single JWK — alg comes from the JWK's own `alg` field or algValue.
+        // Reject symmetric JWKs (kty: "oct") before importing: a symmetric key passed
+        // as publicKey violates the option's asymmetric-only contract and would result
+        // in a confusing jose error rather than a clear configuration error.
+        if (!_jwkKeyCache.has(publicKeyValue)) {
+          _jwkKeyCache.set(publicKeyValue, (async () => {
+            if ((publicKeyValue as JWK).kty === 'oct') {
+              throw new InvalidRequestError(
+                "'publicKey' must be an asymmetric key (RSA, EC, OKP). Use 'secret' for symmetric verification."
+              );
+            }
+            const importedKey = await importJWK(publicKeyValue as JWK, algValue);
+            return importedKey as KeyLike;
+          })());
+        }
+        const importedKey = await _jwkKeyCache.get(publicKeyValue)!;
         const result = await jwtVerify(jwt, importedKey, { clockTolerance });
         payload = result.payload;
         header = result.protectedHeader;
@@ -824,6 +857,15 @@ const jwtVerifier = ({
         jwksUri = jwksUri || discoveredJwksUri;
         issuer = issuer || discoveredIssuer;
         allowedSigningAlgs = idTokenSigningAlgValuesSupported;
+      }
+
+      // For non-discovery paths (publicKey or jwksUri without issuerBaseURL), run early
+      // algorithm validation so that tokens with the wrong alg (e.g. "HS256" or "none")
+      // produce a clear SDK error rather than a confusing jose internal error.
+      // The issuerBaseURL path already calls validateAlgorithmEarly inside its own block
+      // above; MCD mode calls it during issuer matching (STEP 3b).
+      if (!issuerBaseURL && publicKey) {
+        validateAlgorithmEarly(jwt, false);
       }
 
       // Verify signature and validate claims for single issuer mode

--- a/packages/access-token-jwt/test/helpers.ts
+++ b/packages/access-token-jwt/test/helpers.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import { createSecretKey } from 'crypto';
-import { SignJWT, generateKeyPair, exportJWK } from 'jose';
+import { SignJWT, generateKeyPair, exportJWK, exportSPKI } from 'jose';
+import type { JWK, JSONWebKeySet } from 'jose';
 import nock = require('nock');
 
 export const now = (Date.now() / 1000) | 0;
@@ -68,4 +69,48 @@ export const createJwt = async ({
     .setIssuedAt(iat)
     .setExpirationTime(exp)
     .sign(secretKey || privateKey);
+};
+
+export interface CreateJwtWithKeyResult {
+  jwt: string;
+  publicKeyJwk: JWK;
+  publicKeyJwkSet: JSONWebKeySet;
+  publicKeyPem: string;
+}
+
+/**
+ * Create a JWT signed with a freshly generated RS256 key pair and return the
+ * signed token together with the public key in several formats (JWK, JWK Set,
+ * PEM SPKI) so tests can exercise the `publicKey` option without needing a
+ * running JWKS endpoint.
+ */
+export const createJwtWithKey = async ({
+  payload = {},
+  issuer = 'https://issuer.example.com/',
+  subject = 'me',
+  audience = 'https://api/',
+  iat = now,
+  exp = now + 60 * 60 * 24,
+  kid = 'kid',
+}: Omit<CreateJWTOptions, 'jwksUri' | 'discoveryUri' | 'jwksSpy' | 'discoverSpy' | 'delay' | 'secret'> = {}): Promise<CreateJwtWithKeyResult> => {
+  const { publicKey, privateKey } = await generateKeyPair('RS256');
+  const jwk = await exportJWK(publicKey);
+  const publicKeyPem = await exportSPKI(publicKey);
+  const publicKeyJwk: JWK = { ...jwk, kid, alg: 'RS256' };
+
+  const jwt = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'RS256', typ: 'JWT', kid })
+    .setIssuer(issuer)
+    .setSubject(subject)
+    .setAudience(audience)
+    .setIssuedAt(iat)
+    .setExpirationTime(exp)
+    .sign(privateKey);
+
+  return {
+    jwt,
+    publicKeyJwk,
+    publicKeyJwkSet: { keys: [publicKeyJwk] },
+    publicKeyPem,
+  };
 };

--- a/packages/access-token-jwt/test/jwt-verifier.test.ts
+++ b/packages/access-token-jwt/test/jwt-verifier.test.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto';
 import nock from 'nock';
 import sinon from 'sinon';
-import { createJwt, now } from './helpers';
+import { createJwt, createJwtWithKey, now } from './helpers';
 import { jwtVerifier, InvalidTokenError } from '../src';
 import validate from '../src/validate.js';
 
@@ -14,7 +14,7 @@ describe('jwt-verifier', () => {
         audience: 'https://api/',
       })
     ).toThrowError(
-      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri', 'secret', or 'publicKey')"
     );
   });
 
@@ -1169,7 +1169,7 @@ describe('jwt-verifier', () => {
       });
 
       await expect(verify(jwt)).rejects.toThrowError(
-        'No JWKS URI or secret available for verification'
+        'No JWKS URI, public key, or secret available for verification'
       );
     });
 
@@ -1478,4 +1478,372 @@ describe('jwt-verifier', () => {
         }).toThrow('Invalid issuer URL: URLs must not contain userinfo (username:password)');
       });
     });
+
+  // ---------------------------------------------------------------------------
+  // publicKey option (issue #133)
+  // ---------------------------------------------------------------------------
+  describe('publicKey option (static asymmetric key without discovery)', () => {
+    // -- Configuration validation --------------------------------------------
+
+    it('should throw when publicKey and jwksUri are both provided', () => {
+      expect(() =>
+        jwtVerifier({
+          issuer: 'https://issuer.example.com/',
+          audience: 'https://api/',
+          jwksUri: 'https://issuer.example.com/.well-known/jwks.json',
+          publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+          tokenSigningAlg: 'RS256',
+        })
+      ).toThrowError("You must not provide both a 'publicKey' and 'jwksUri'");
+    });
+
+    it('should throw when publicKey and secret are both provided', () => {
+      expect(() =>
+        jwtVerifier({
+          issuer: 'https://issuer.example.com/',
+          audience: 'https://api/',
+          secret: 'some-secret',
+          publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+          tokenSigningAlg: 'HS256',
+        })
+      ).toThrowError("You must not provide both a 'publicKey' and 'secret'");
+    });
+
+    it('should throw when publicKey and issuerBaseURL are both provided', () => {
+      expect(() =>
+        jwtVerifier({
+          issuerBaseURL: 'https://issuer.example.com/',
+          audience: 'https://api/',
+          publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+          tokenSigningAlg: 'RS256',
+        })
+      ).toThrowError("You must not provide both a 'publicKey' and 'issuerBaseURL'");
+    });
+
+    it('should throw when top-level publicKey is combined with mcd', () => {
+      expect(() =>
+        jwtVerifier({
+          mcd: { issuers: ['https://tenant1.example.com/'] },
+          audience: 'https://api/',
+          publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+        })
+      ).toThrowError('Cannot use top-level "publicKey" with mcd mode.');
+    });
+
+    it('should throw when PEM publicKey is used without tokenSigningAlg', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey();
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyPem,
+        // tokenSigningAlg intentionally omitted
+      });
+      await expect(verify(jwt)).rejects.toThrowError(
+        "You must provide 'tokenSigningAlg' (or 'alg' in the issuer config) when using a PEM public key"
+      );
+    });
+
+    // -- Successful verification with PEM ------------------------------------
+
+    it('should verify token using PEM SPKI public key', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey();
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyPem,
+        tokenSigningAlg: 'RS256',
+      });
+      await expect(verify(jwt)).resolves.toHaveProperty('payload', {
+        iss: 'https://issuer.example.com/',
+        sub: 'me',
+        aud: 'https://api/',
+        iat: expect.any(Number),
+        exp: expect.any(Number),
+      });
+    });
+
+    it('should reject a token signed with a different key when using PEM', async () => {
+      const { jwt } = await createJwtWithKey();
+      // Generate a completely different key for verification
+      const { publicKeyPem: wrongPem } = await createJwtWithKey();
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: wrongPem,
+        tokenSigningAlg: 'RS256',
+      });
+      await expect(verify(jwt)).rejects.toThrow(InvalidTokenError);
+    });
+
+    // -- Successful verification with JWK ------------------------------------
+
+    it('should verify token using a single JWK public key', async () => {
+      const { jwt, publicKeyJwk } = await createJwtWithKey();
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyJwk,
+        tokenSigningAlg: 'RS256',
+      });
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://issuer.example.com/');
+    });
+
+    it('should verify token using a JWK with alg field (no tokenSigningAlg needed)', async () => {
+      const { jwt, publicKeyJwk } = await createJwtWithKey();
+      // publicKeyJwk already has alg: 'RS256' set by createJwtWithKey
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyJwk,
+        // tokenSigningAlg intentionally omitted — alg comes from the JWK
+      });
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://issuer.example.com/');
+    });
+
+    // -- Successful verification with JWK Set --------------------------------
+
+    it('should verify token using an inline JWK Set', async () => {
+      const { jwt, publicKeyJwkSet } = await createJwtWithKey();
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyJwkSet,
+      });
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.sub', 'me');
+    });
+
+    it('should reject a token when the kid does not match any key in the inline JWK Set', async () => {
+      const { jwt } = await createJwtWithKey({ kid: 'key-1' });
+      // JWK Set contains a key with a different kid
+      const { publicKeyJwkSet } = await createJwtWithKey({ kid: 'key-2' });
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        publicKey: publicKeyJwkSet,
+      });
+      await expect(verify(jwt)).rejects.toThrow(InvalidTokenError);
+    });
+
+    // -- No discovery / no network calls -------------------------------------
+
+    it('should not make any network requests when publicKey is provided', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey();
+      // nock.disableNetConnect would throw on any network call; the test passes
+      // only if the verifier uses the static key without hitting the network.
+      nock.disableNetConnect();
+      try {
+        const verify = jwtVerifier({
+          issuer: 'https://issuer.example.com/',
+          audience: 'https://api/',
+          publicKey: publicKeyPem,
+          tokenSigningAlg: 'RS256',
+        });
+        await expect(verify(jwt)).resolves.toHaveProperty('payload');
+      } finally {
+        nock.enableNetConnect();
+      }
+    });
+
+    // -- MCD with publicKey --------------------------------------------------
+
+    it('should verify token in MCD mode using per-issuer PEM publicKey', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey({
+        issuer: 'https://tenant1.example.com/',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: [
+            {
+              issuer: 'https://tenant1.example.com/',
+              publicKey: publicKeyPem,
+              alg: 'RS256',
+            },
+          ],
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://tenant1.example.com/');
+    });
+
+    it('should verify token in MCD mode using per-issuer JWK publicKey', async () => {
+      const { jwt, publicKeyJwk } = await createJwtWithKey({
+        issuer: 'https://tenant2.example.com/',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: [
+            {
+              issuer: 'https://tenant2.example.com/',
+              publicKey: publicKeyJwk,
+            },
+          ],
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://tenant2.example.com/');
+    });
+
+    it('should verify token in MCD mode using per-issuer JWK Set publicKey', async () => {
+      const { jwt, publicKeyJwkSet } = await createJwtWithKey({
+        issuer: 'https://tenant3.example.com/',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: [
+            {
+              issuer: 'https://tenant3.example.com/',
+              publicKey: publicKeyJwkSet,
+            },
+          ],
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://tenant3.example.com/');
+    });
+
+    it('should support mixed MCD issuers: one with publicKey, one with JWKS discovery', async () => {
+      const { jwt: jwtStatic, publicKeyPem } = await createJwtWithKey({
+        issuer: 'https://static.example.com/',
+      });
+      const jwtDiscovery = await createJwt({
+        issuer: 'https://discovery.example.com/',
+        jwksUri: '/.well-known/jwks.json',
+        discoveryUri: '/.well-known/openid-configuration',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: [
+            {
+              issuer: 'https://static.example.com/',
+              publicKey: publicKeyPem,
+              alg: 'RS256',
+            },
+            'https://discovery.example.com/',
+          ] as any,
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwtStatic)).resolves.toHaveProperty('payload.iss', 'https://static.example.com/');
+      await expect(verify(jwtDiscovery)).resolves.toHaveProperty('payload.iss', 'https://discovery.example.com/');
+    });
+
+    it('should throw in MCD static config when issuer has both publicKey and jwksUri', () => {
+      expect(() =>
+        jwtVerifier({
+          mcd: {
+            issuers: [
+              {
+                issuer: 'https://tenant1.example.com/',
+                publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+                jwksUri: 'https://tenant1.example.com/.well-known/jwks.json',
+              },
+            ],
+          },
+          audience: 'https://api/',
+        })
+      ).toThrowError(
+        "provides both 'publicKey' and 'jwksUri'. These are mutually exclusive."
+      );
+    });
+
+    it('should throw in MCD static config when issuer has both publicKey and secret', () => {
+      expect(() =>
+        jwtVerifier({
+          mcd: {
+            issuers: [
+              {
+                issuer: 'https://tenant1.example.com/',
+                publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
+                secret: 'my-secret',
+                alg: 'HS256',
+              } as any,
+            ],
+          },
+          audience: 'https://api/',
+        })
+      ).toThrowError(
+        "provides both 'publicKey' and 'secret'."
+      );
+    });
+
+    it('should throw at runtime when dynamic resolver returns issuer with both publicKey and secret', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey({
+        issuer: 'https://tenant-dynamic.example.com/',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: async () => [
+            {
+              issuer: 'https://tenant-dynamic.example.com/',
+              publicKey: publicKeyPem,
+              secret: 'my-secret',
+              alg: 'HS256',
+            } as any,
+          ],
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwt)).rejects.toThrowError(
+        "Issuer provides both 'publicKey' and 'secret'. These are mutually exclusive."
+      );
+    });
+
+    it('should throw at runtime when dynamic resolver returns issuer with both publicKey and jwksUri', async () => {
+      const { jwt, publicKeyPem } = await createJwtWithKey({
+        issuer: 'https://tenant-dynamic2.example.com/',
+      });
+
+      const verify = jwtVerifier({
+        mcd: {
+          issuers: async () => [
+            {
+              issuer: 'https://tenant-dynamic2.example.com/',
+              publicKey: publicKeyPem,
+              jwksUri: 'https://tenant-dynamic2.example.com/.well-known/jwks.json',
+            },
+          ],
+        },
+        audience: 'https://api/',
+      });
+
+      await expect(verify(jwt)).rejects.toThrowError(
+        "Issuer provides both 'publicKey' and 'jwksUri'. These are mutually exclusive."
+      );
+    });
+
+    it('should make no network requests for MCD with publicKey (no discovery)', async () => {
+      const { jwt, publicKeyJwkSet } = await createJwtWithKey({
+        issuer: 'https://tenant-static.example.com/',
+      });
+
+      nock.disableNetConnect();
+      try {
+        const verify = jwtVerifier({
+          mcd: {
+            issuers: [
+              {
+                issuer: 'https://tenant-static.example.com/',
+                publicKey: publicKeyJwkSet,
+              },
+            ],
+          },
+          audience: 'https://api/',
+        });
+
+        await expect(verify(jwt)).resolves.toHaveProperty('payload');
+      } finally {
+        nock.enableNetConnect();
+      }
+    });
+  });
 });

--- a/packages/access-token-jwt/test/jwt-verifier.test.ts
+++ b/packages/access-token-jwt/test/jwt-verifier.test.ts
@@ -1588,6 +1588,23 @@ describe('jwt-verifier', () => {
       await expect(verify(jwt)).resolves.toHaveProperty('payload.iss', 'https://issuer.example.com/');
     });
 
+    it('should throw when a symmetric JWK (kty: "oct") is passed as publicKey', async () => {
+      // createJwtWithKey() produces an RS256-signed token; validateAlgorithmEarly passes.
+      // The symmetric JWK carries its own alg: 'HS256' so importJWK returns Uint8Array,
+      // which our guard catches and rejects with a clear error.
+      const { jwt } = await createJwtWithKey();
+      const symmetricJwk = { kty: 'oct', k: 'c2VjcmV0LWtleQ', alg: 'HS256' };
+      const verify = jwtVerifier({
+        issuer: 'https://issuer.example.com/',
+        audience: 'https://api/',
+        // tokenSigningAlg omitted — alg comes from the JWK's own field
+        publicKey: symmetricJwk as any,
+      });
+      await expect(verify(jwt)).rejects.toThrowError(
+        "'publicKey' must be an asymmetric key (RSA, EC, OKP). Use 'secret' for symmetric verification."
+      );
+    });
+
     it('should verify token using a JWK with alg field (no tokenSigningAlg needed)', async () => {
       const { jwt, publicKeyJwk } = await createJwtWithKey();
       // publicKeyJwk already has alg: 'RS256' set by createJwtWithKey
@@ -1725,8 +1742,10 @@ describe('jwt-verifier', () => {
               publicKey: publicKeyPem,
               alg: 'RS256',
             },
+            // @ts-expect-error — mixed array of AsymmetricIssuerConfig + string is valid at
+            // runtime but MCDOptions.issuers is typed as string[] | IssuerConfig[] (not mixed)
             'https://discovery.example.com/',
-          ] as any,
+          ],
         },
         audience: 'https://api/',
       });
@@ -1764,7 +1783,7 @@ describe('jwt-verifier', () => {
                 publicKey: '-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----',
                 secret: 'my-secret',
                 alg: 'HS256',
-              } as any,
+              },
             ],
           },
           audience: 'https://api/',
@@ -1787,7 +1806,7 @@ describe('jwt-verifier', () => {
               publicKey: publicKeyPem,
               secret: 'my-secret',
               alg: 'HS256',
-            } as any,
+            },
           ],
         },
         audience: 'https://api/',

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -10,6 +10,10 @@
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
   - [Static list of issuers](#static-list-of-issuers)
   - [Dynamic resolver](#dynamic-resolver)
+- [Static Public Key Verification](#static-public-key-verification)
+  - [PEM-encoded SPKI string](#pem-encoded-spki-string)
+  - [Single JWK object](#single-jwk-object)
+  - [Inline JWK Set](#inline-jwk-set)
 - [Restrict access with scopes](#restrict-access-with-scopes)
 - [Restrict access with claims](#restrict-access-with-claims)
   - [Matching a specific value](#matching-a-specific-value)
@@ -346,6 +350,64 @@ auth({
     jwks:      { maxEntries: 50, ttl: 300_000 },
   }
 })
+```
+
+## Static Public Key Verification
+
+Use `publicKey` when you already have the issuer's public key and want to skip OIDC discovery and remote JWKS fetches entirely. This option is mutually exclusive with `issuerBaseURL`, `jwksUri`, and `secret`.
+
+### PEM-encoded SPKI string
+
+`tokenSigningAlg` is required when providing a PEM key, since the algorithm cannot be inferred from the key material alone.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: '-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----',
+    tokenSigningAlg: 'RS256',
+  })
+);
+```
+
+### Single JWK object
+
+The `alg` field in the JWK is used for algorithm selection. If omitted, provide `tokenSigningAlg`.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: { kty: 'EC', crv: 'P-256', x: '...', y: '...', alg: 'ES256' },
+  })
+);
+```
+
+### Inline JWK Set
+
+Key selection uses the token's `kid` header matched against each key's `kid` field. Useful when the issuer rotates keys.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: {
+      keys: [
+        { kty: 'RSA', n: '...', e: 'AQAB', alg: 'RS256', kid: 'key-1' },
+        { kty: 'RSA', n: '...', e: 'AQAB', alg: 'RS256', kid: 'key-2' },
+      ],
+    },
+  })
+);
 ```
 
 ## Restrict access with scopes

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -85,6 +85,42 @@ app.get('/api/messages', (req, res, next) => {
 });
 ```
 
+#### JWTs verified with a static public key (no discovery)
+
+Use this when you already have the issuer's public key and want to skip OIDC discovery or a remote JWKS endpoint entirely. Accepted formats: PEM-encoded SPKI string, a single JWK object, or an inline JWK Set.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+// PEM-encoded SPKI public key
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: '-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----',
+    tokenSigningAlg: 'RS256',
+  })
+);
+
+// Inline JWK
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: { kty: 'EC', crv: 'P-256', x: '...', y: '...', alg: 'ES256' },
+  })
+);
+
+// Inline JWK Set
+app.use(
+  auth({
+    issuer: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    publicKey: { keys: [{ kty: 'RSA', n: '...', e: 'AQAB', alg: 'RS256', kid: '...' }] },
+  })
+);
+```
+
 #### DPoP Authentication
 
 This SDK supports [DPoP (Demonstration of Proof-of-Possession)](https://datatracker.ietf.org/doc/html/rfc9449), which enhances access token security by requiring clients to prove possession of a private key associated with each request.

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -206,6 +206,7 @@ export {
   Validators,
   JWTHeader,
   JSONPrimitive,
+  PublicKeyInput,
   MCDOptions,
   AsymmetricIssuerConfig,
   SymmetricIssuerConfig,

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -118,7 +118,7 @@ describe('index', () => {
   it('should accept empty arguments and env vars', async () => {
     const env = process.env;
     await expect(auth).toThrowError(
-      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri' or 'secret')"
+      "You must provide 'mcd', 'issuerBaseURL', or both 'issuer' and ('jwksUri', 'secret', or 'publicKey')"
     );
     process.env = Object.assign({}, env, {
       ISSUER_BASE_URL: 'foo',


### PR DESCRIPTION
### Description

This PR adds support for directly providing a public key for JWT verification without requiring JWKS discovery or endpoints, addressing issue #133.

  Currently, the library only supports:
  1. Using `issuerBaseURL` to fetch JWKS via discovery
  2. Manually providing `jwksUri` and `issuer`
  3. Symmetric keys via string `secret`

This change adds a new `publicKey` option to `JwtVerifierOptions` accepting a static asymmetric public key, enabling JWT verification without any network dependencies.

#### Changes

  **Core Implementation:**
 - Added new `publicKey` option (`PublicKeyInput type: string | JWK | JSONWebKeySet`) to `JwtVerifierOptions` and per-issuer `AsymmetricIssuerConfig`
  - Added static key verification in `jwt-verifier.ts` supporting PEM SPKI strings, single JWK objects, and inline JWK Sets
  - Lazy key-import caching so the expensive import is only done once per unique key
  - Guards against symmetric JWKs (kty: "oct") being passed as `publicKey`
  - Exported PublicKeyInput type for user convenience

### References

Fixes #133 

### Testing


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
