### PR TITLE
fix: use Node 22.22.1 in publish workflow for npm@11 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      node-version: 18
+      node-version: 22.22.1
       artifact-name: "node-oauth2-jwt-bearer.tgz"
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/npm-release.yml
     needs: rl-scanner
     with:
-      node-version: 18
+      node-version: 22.22.1
       require-build: true
       release-directory: "./packages/express-oauth2-jwt-bearer"
     secrets:


### PR DESCRIPTION
### Description

The publish workflow was failing because it was using Node 18, which is incompatible with npm@11. The npm install -g npm@11 step requires Node ^20.17.0 || >=22.9.0, causing the publish pipeline to error out immediately.                                                                                                              
                                         
This PR updates the node-version in publish.yml from 18 to 22.22.1 for both the rl-scanner and release jobs. Node 22.22.1 satisfies the npm@11 engine requirement and aligns with the Node version used in other Auth0 SDK publish workflows (e.g. auth0/lock#2774).

No application code or SDK behaviour is changed, this is a CI pipeline fix only.

### References

  - auth0/lock#2774 - same fix applied to the lock repo
  
### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
