### PR TITLE
release v1.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage
 test-results
 *.code-workspace
 package-lock.json
+# Forge workspace (local, do not commit upstream)
+.forge/

--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -28,6 +28,7 @@ export {
   InvalidTokenError,
   UnauthorizedError,
   InsufficientScopeError,
+  InvalidRequestError,
 } from 'oauth2-bearer';
 export { default as discover, IssuerMetadata } from './discovery';
 export {

--- a/packages/access-token-jwt/test/dpop-verifier.test.ts
+++ b/packages/access-token-jwt/test/dpop-verifier.test.ts
@@ -972,4 +972,24 @@ describe('verifyDPoP', () => {
     expect(proofHeader.kid).toBe('kid-xyz');
     expect((proofHeader as any)['x-extra']).toBe('hdr-ok');
   });
+
+  describe('normalizeUrl regression (no query/fragment rejection on request)', () => {
+    // UT-11: request URL with query is stripped, NOT rejected
+    it('UT-11: normalizeUrl strips query from request URL', () => {
+      const result = normalizeUrl('http://h.com/p?x=1', 'request');
+      expect(result).toBe('http://h.com/p');
+    });
+
+    // UT-12: request URL with fragment is stripped, NOT rejected
+    it('UT-12: normalizeUrl strips fragment from request URL', () => {
+      const result = normalizeUrl('http://h.com/p#f', 'request');
+      expect(result).toBe('http://h.com/p');
+    });
+
+    // UT-13: proof htu with query/fragment stripped (unchanged)
+    it('UT-13: normalizeUrl strips query and fragment from proof htu', () => {
+      const result = normalizeUrl('https://h.com/p?x=1#f', 'proof');
+      expect(result).toBe('https://h.com/p');
+    });
+  });
 });

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -238,4 +238,15 @@ describe('index', () => {
       } as any)
     ).toThrow();
   });
+
+  describe('InvalidRequestError re-export', () => {
+    // UT-10: InvalidRequestError exported from access-token-jwt
+    it('UT-10: exports InvalidRequestError with correct statusCode', () => {
+      const { InvalidRequestError } = require('../src/index.ts');
+      expect(InvalidRequestError).toBeDefined();
+      const err = new InvalidRequestError('test message');
+      expect(err.statusCode).toBe(400);
+      expect(err.message).toBe('test message');
+    });
+  });
 });

--- a/packages/express-oauth2-jwt-bearer/CHANGELOG.md
+++ b/packages/express-oauth2-jwt-bearer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.9.1](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.9.1) (2026-06-23)
+[Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.9.0...v1.9.1)
+
+**Security**
+- fix: reject malformed `Host`/`X-Forwarded-Host` headers before URL construction to close a DPoP `htu` cross-endpoint replay bypass ([tusharpandey13](https://github.com/tusharpandey13))
+
 ## [v1.9.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.9.0) (2026-05-19)
 [Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.8.0...v1.9.0)
 

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -140,6 +140,25 @@ This SDK uses `req.protocol` and `req.host` to construct the `htu` (HTTP URI) cl
     app.enable('trust proxy');
     ```
 
+#### Host Header Validation
+
+The SDK validates the `Host` header to prevent security issues before constructing the request URL. Any `Host` header containing invalid characters (`/`, `?`, `#`, `://`) or failing to match the hostname grammar will be rejected with a `400 invalid_request` response.
+
+This validation applies to all requests, not just DPoP requests. The hostname must conform to [RFC 7230](https://tools.ietf.org/html/rfc7230#section-2.7.1):
+
+Valid hostnames:
+- `example.com`
+- `example.com:8443`
+- `[::1]` (IPv6 literal)
+- `[::1]:3000`
+
+Invalid hostnames (will be rejected):
+- `example.com/path` (path embedded in host)
+- `example.com?query=value` (query in host)
+- `https://example.com` (scheme in host)
+
+This is a security control that prevents host-injection attacks and does not require any configuration. Standards-compliant clients always send valid `Host` headers and are not affected.
+
 ### DPoP jti Replay Prevention
 
 > [!WARNING]

--- a/packages/express-oauth2-jwt-bearer/package.json
+++ b/packages/express-oauth2-jwt-bearer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-oauth2-jwt-bearer",
   "description": "Authentication middleware for Express.js that validates JWT bearer access tokens.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "auth0/node-oauth2-jwt-bearer",

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -82,8 +82,18 @@ export const auth = (opts: AuthOptions = {}): Handler => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const { headers, query, body, method } = req;
 
-    // Construct the URL from the request object.
-    const url = `${req.protocol}://${resolveHost(req)}${req.originalUrl ?? req.url}`;
+    // Construct the URL from the request object. resolveHost validates the
+    // untrusted Host header and throws InvalidRequestError on a malformed value,
+    // so this runs before any verifier is constructed.
+    let url: string;
+    try {
+      url = `${req.protocol}://${resolveHost(req)}${req.originalUrl ?? req.url}`;
+    } catch (e) {
+      if (opts.authRequired === false) {
+        return next();
+      }
+      return next(e);
+    }
 
     // Get DPoP verifier instance with the provided options.
     const requestOptions: RequestLike = {

--- a/packages/express-oauth2-jwt-bearer/src/resolve-host.ts
+++ b/packages/express-oauth2-jwt-bearer/src/resolve-host.ts
@@ -1,7 +1,28 @@
 import type { Request } from 'express';
+import { InvalidRequestError } from 'access-token-jwt';
+
+// Hostname grammar: a registered name or bracketed IPv6 literal, with an
+// optional :port. Mirrors the host check used during DPoP htu normalization.
+const HOST_RE = /^(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d{1,5})?$/;
+
+// Validate the raw, untrusted host value BEFORE it is concatenated into a URL.
+// Rejecting structural characters here prevents Host-header injection from
+// being laundered into the query/fragment by later URL parsing.
+function isValidHost(host: string | undefined): host is string {
+  return (
+    typeof host === 'string' &&
+    host.length > 0 &&
+    !host.includes('://') &&
+    !host.includes('/') &&
+    !host.includes('?') &&
+    !host.includes('#') &&
+    HOST_RE.test(host)
+  );
+}
 
 // Resolve host in a way that's compatible with both Express 4 and 5.
-export function resolveHost(req: Request): string | undefined {
+// Throws InvalidRequestError if the resolved host is missing or malformed.
+export function resolveHost(req: Request): string {
   // Extract the trust proxy function from the app settings
   const trust = req.app?.get?.('trust proxy fn');
 
@@ -16,15 +37,21 @@ export function resolveHost(req: Request): string | undefined {
     !host ||
     !(typeof trust === 'function' && trust(req.socket?.remoteAddress, 0))
   ) {
-    return get ? get('Host') : undefined;
+    host = get ? get('Host') : undefined;
+  } else {
+    // If XFH had multiple values, only keep the first one
+    const i = host.indexOf(',');
+    if (i !== -1) {
+      host = host.substring(0, i).trimEnd(); // trim spaces after the first value
+    }
   }
 
-  // If XFH had multiple values, only keep the first one
-  const i = host.indexOf(',');
-  if (i !== -1) {
-    host = host.substring(0, i).trimEnd(); // trim spaces after the first value
+  // Validate the untrusted host at the single return point, covering both the
+  // X-Forwarded-Host and Host paths. A single generic message is used for every
+  // reason so we don't signal which check failed.
+  if (!isValidHost(host)) {
+    throw new InvalidRequestError('Invalid Host header');
   }
 
-  // At this point host is either the first XFH value or a single host
-  return host || undefined;
+  return host;
 }

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -527,5 +527,53 @@ describe('index', () => {
     server.close();
   });
   
-  
+
+  describe('Host injection rejection (DPoP htu bypass fix)', () => {
+    // FT-1: attack ? variant rejected
+    test('FT-1: rejects GET with Host carrying injected path+query (?)', async () => {
+      const baseUrl = await setup({
+        dpop: { enabled: true, required: true },
+      });
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { host: 'localhost/intendedPath?' },
+          responseType: 'json',
+        }),
+        400,
+        'invalid_request'
+      );
+    });
+
+    // FT-2: attack # variant rejected
+    test('FT-2: rejects GET with Host carrying injected path+fragment (#)', async () => {
+      const baseUrl = await setup({
+        dpop: { enabled: true, required: true },
+      });
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { host: 'localhost/intendedPath#' },
+          responseType: 'json',
+        }),
+        400,
+        'invalid_request'
+      );
+    });
+
+    // FT-6: invalid host with authRequired:false proceeds
+    test('FT-6: invalid host with authRequired:false passes through', async () => {
+      const baseUrl = await setup({
+        authRequired: false,
+        dpop: { enabled: true },
+      });
+      const response = await got(baseUrl, {
+        headers: { host: 'resource.com/evil?' },
+        responseType: 'json',
+      });
+      // Should reach the downstream handler without throwing
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeFalsy(); // No auth, so req.auth is undefined
+    });
+
+  });
+
 });

--- a/packages/express-oauth2-jwt-bearer/test/resolve-host.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/resolve-host.test.ts
@@ -97,19 +97,6 @@ describe('resolveHost (Express 4/5 compatible)', () => {
     expect(resolveHost(req)).toBe('internal:3000');
   });
 
-  test('returns undefined when both Host and X-Forwarded-Host are missing', () => {
-    const req = mkReq({ trustFn: () => true });
-    expect(resolveHost(req)).toBeUndefined();
-  });
-
-  test('returns X-Forwarded-Host when Host is missing but proxy is trusted', () => {
-    const req = mkReq({
-      xfh: 'public.example.com',
-      trustFn: () => true,
-    });
-    expect(resolveHost(req)).toBe('public.example.com');
-  });
-
   test('returns Host when req.app is missing entirely', () => {
     const req = mkReq({ host: 'internal:3000', xfh: 'api.example.com' }) as any;
     delete req.app; // simulate no app on the request
@@ -178,14 +165,6 @@ describe('resolveHost (Express 4/5 compatible)', () => {
     expect(resolveHost(req)).toBe('internal:3000');
   });
 
-  test('Host missing, XFH present, undefined trust fn returns undefined', () => {
-    const req = mkReq({
-      xfh: 'api.example.com',
-      trustFn: undefined,
-    });
-    expect(resolveHost(req)).toBeUndefined();
-  });
-
   test('Host missing, XFH multi-value, trusted returns first XFH', () => {
     const req = mkReq({
       xfh: 'a.example.com, b.example.com',
@@ -194,46 +173,10 @@ describe('resolveHost (Express 4/5 compatible)', () => {
     expect(resolveHost(req)).toBe('a.example.com');
   });
 
-  test('returns undefined when req.get is missing entirely', () => {
-    const req = mkReq({
-      host: 'internal:3000',
-      xfh: 'api.example.com',
-      trustFn: () => true,
-      noGet: true,
-    });
-    expect(resolveHost(req)).toBeUndefined();
-  });
-
-  test('returns empty string when Host is an empty string and XFH is missing', () => {
-    const req = mkReq({
-      host: '',
-      trustFn: () => true,
-    });
-    expect(resolveHost(req)).toBe('');
-  });
-
   test('returns XFH when req.socket is missing', () => {
     const req = mkReq({ host: 'internal:3000', xfh: 'api.example.com', trustFn: () => true }) as any;
     delete req.socket; // simulate no socket on the request
     expect(resolveHost(req)).toBe('api.example.com');
-  });
-
-  test('returns exact XFH when trusted and no comma present (no trimming path)', () => {
-    const req = mkReq({
-      xfh: 'edge.example.com   ',
-      host: 'internal:3000',
-      trustFn: () => true,
-    });
-    expect(resolveHost(req)).toBe('edge.example.com   ');
-  });
-
-  test('returns undefined when first XFH value is whitespace only after trimming', () => {
-    const req = mkReq({
-      xfh: '   , b.example.com',
-      host: 'internal:3000',
-      trustFn: () => true,
-    });
-    expect(resolveHost(req)).toBeUndefined();
   });
 
   test('does not throw if remoteAddress is undefined and proxy is trusted unconditionally', () => {
@@ -244,5 +187,223 @@ describe('resolveHost (Express 4/5 compatible)', () => {
       trustFn: () => true,
     });
     expect(resolveHost(req)).toBe('pub.example.com');
+  });
+
+  describe('Unit: Host Validation (new throwing contract)', () => {
+    // UT-1: valid plain host
+    test('UT-1: valid plain host returns string', () => {
+      const req = mkReq({ host: 'resource.com', trustFn: () => true });
+      expect(resolveHost(req)).toBe('resource.com');
+    });
+
+    // UT-2: host with port
+    test('UT-2: host with port returns string', () => {
+      const req = mkReq({ host: 'resource.com:8443', trustFn: () => true });
+      expect(resolveHost(req)).toBe('resource.com:8443');
+    });
+
+    // UT-3: IPv6 literal host
+    test('UT-3: IPv6 literal host returns string', () => {
+      const req = mkReq({ host: '[::1]:3000', trustFn: () => true });
+      expect(resolveHost(req)).toBe('[::1]:3000');
+    });
+
+    // UT-4: injected path+query in Host throws
+    test('UT-4: injected path+query in Host throws InvalidRequestError', () => {
+      const req = mkReq({ host: 'resource.com/intendedPath?', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-5: injected fragment in Host throws
+    test('UT-5: injected fragment in Host throws InvalidRequestError', () => {
+      const req = mkReq({ host: 'resource.com/intendedPath#', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-6: double-slash in Host throws
+    test('UT-6: double-slash in Host throws InvalidRequestError', () => {
+      const req = mkReq({ host: 'resource.com//evil', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-7: scheme-in-Host throws
+    test('UT-7: scheme-in-Host throws InvalidRequestError', () => {
+      const req = mkReq({ host: 'https://resource.com', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-8: trusted XFH carrying injection throws
+    test('UT-8: trusted XFH carrying injection throws InvalidRequestError', () => {
+      const req = mkReq({ host: 'internal:3000', xfh: 'resource.com/x?', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-9: trusted multi-value XFH keeps and validates first value
+    test('UT-9: trusted multi-value XFH keeps and validates first value', () => {
+      const req = mkReq({ host: 'internal:3000', xfh: 'a.com, b.com', trustFn: () => true });
+      expect(resolveHost(req)).toBe('a.com');
+    });
+
+    // UT-EMPTY: trusted XFH leading-comma yields empty -> throws
+    test('UT-EMPTY: trusted XFH leading-comma yields empty -> throws', () => {
+      const req = mkReq({ xfh: ', b.com', host: 'internal:3000', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // UT-MSG: single generic reject message across reasons
+    test('UT-MSG: single generic reject message (structural char reject)', () => {
+      const req = mkReq({ host: 'resource.com/evil?', trustFn: () => true });
+      let thrown: any;
+      try {
+        resolveHost(req);
+        fail('Should throw');
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown.message).toBe('Invalid Host header');
+    });
+
+    test('UT-MSG: single generic reject message (missing-host reject)', () => {
+      const req = mkReq({ trustFn: () => true }); // no host, no xfh
+      let thrown: any;
+      try {
+        resolveHost(req);
+        fail('Should throw');
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown.message).toBe('Invalid Host header');
+    });
+
+    // EC-1: trailing-dot host
+    test('EC-1: trailing-dot host accepted and returned', () => {
+      const req = mkReq({ host: 'resource.com.', trustFn: () => true });
+      expect(resolveHost(req)).toBe('resource.com.');
+    });
+
+    // EC-2: userinfo in host rejected
+    test('EC-2: userinfo in host rejected', () => {
+      const req = mkReq({ host: 'user:pass@resource.com', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // EC-3: port-only overflow / non-numeric port
+    test('EC-3: non-numeric port rejected', () => {
+      const req = mkReq({ host: 'resource.com:notaport', trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+  });
+
+  describe('Migration: Old contract -> New throwing contract', () => {
+    // MIG-1: "returns undefined when both Host and XFH missing" -> now throws
+    test('MIG-1: throws when both Host and X-Forwarded-Host are missing', () => {
+      const req = mkReq({ trustFn: () => true });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // MIG-2: "Host missing, XFH present, undefined trust fn returns undefined" -> now throws
+    test('MIG-2: throws when Host missing, XFH present, undefined trust fn', () => {
+      const req = mkReq({
+        xfh: 'api.example.com',
+        trustFn: undefined,
+      });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // MIG-3: "returns undefined when req.get is missing entirely" -> now throws
+    test('MIG-3: throws when req.get is missing entirely', () => {
+      const req = mkReq({
+        host: 'internal:3000',
+        xfh: 'api.example.com',
+        trustFn: () => true,
+        noGet: true,
+      });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // MIG-4: "returns empty string when Host is empty and XFH missing" -> now throws
+    test('MIG-4: throws when Host is empty string and XFH missing', () => {
+      const req = mkReq({
+        host: '',
+        trustFn: () => true,
+      });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // MIG-5: "returns exact XFH when trusted and no comma (no trimming)" with trailing spaces -> now throws
+    test('MIG-5: throws when trusted XFH has trailing spaces that fail HOST_RE', () => {
+      const req = mkReq({
+        xfh: 'edge.example.com   ',
+        host: 'internal:3000',
+        trustFn: () => true,
+      });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
+
+    // MIG-6: "returns undefined when first XFH value is whitespace only after trimming" -> now throws
+    test('MIG-6: throws when first XFH value is whitespace only after trimming', () => {
+      const req = mkReq({
+        xfh: '   , b.example.com',
+        host: 'internal:3000',
+        trustFn: () => true,
+      });
+      expect(() => resolveHost(req)).toThrow(
+        expect.objectContaining({
+          message: 'Invalid Host header',
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
**Security**
- fix: reject malformed `Host`/`X-Forwarded-Host` headers before URL construction to close a DPoP `htu` cross-endpoint replay bypass

## Summary

Patch release addressing a DPoP `htu` cross-endpoint replay bypass that the `v1.9.0` remediation failed to block.

An attacker holding a stolen DPoP proof and its bound access token could replay the proof against a different path by embedding that path in the `Host` header (e.g. `Host: resource.com/intendedPath?`). String concatenation followed by WHATWG URL parsing relocated the injected path into the query/fragment, which the normalizer then stripped — leaving a laundered host that matched the stolen proof's `htu`.

The fix validates the raw, untrusted host value **before** the URL string is assembled (the only layer with access to the host/path boundary):
- New internal `isValidHost` guard + `HOST_RE` grammar in `resolve-host.ts`; `resolveHost` now throws `InvalidRequestError` on any host carrying `://`, `/`, `?`, `#`, or failing the hostname grammar.
- `InvalidRequestError` re-exported from `access-token-jwt`.
- Express adapter wraps URL construction in try/catch; malformed/missing `Host` on required-auth now yields `400 invalid_request` (was a degenerate `401`). `authRequired: false` requests still pass through.

`normalizeUrl` is intentionally unchanged — it operates on the already-concatenated URL and cannot recover the boundary, and legitimate request URLs carry query strings.

## Behavioral change

- Malformed or missing `Host` on required-auth requests → `400 invalid_request`. Standards-compliant clients always send a valid `Host` and are unaffected.

## Test plan

- [x] `access-token-jwt`: 421/421 passing, 100% coverage
- [x] `express-oauth2-jwt-bearer`: 66/66 passing, 100% coverage
- [x] New unit tests: host validation (valid hosts, ports, IPv6, injection variants `?`/`#`/`//`/`://`, userinfo, bad port), `InvalidRequestError` re-export, `normalizeUrl` regression (query/fragment stripped not rejected)
- [x] Migrated 6 existing `resolve-host` tests from the old non-throwing contract to the new throwing contract
- [x] Flow tests: host-injection rejection end-to-end (`?`/`#`), `authRequired: false` pass-through

A GitHub Security Advisory should be published alongside this release documenting the prior ineffective fix and the corrected behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)