### PR TITLE
release v1.9.1

### DIFF
--- a/packages/express-oauth2-jwt-bearer/CHANGELOG.md
+++ b/packages/express-oauth2-jwt-bearer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.9.1](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.9.1) (2026-06-23)
+[Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.9.0...v1.9.1)
+
+**Security**
+- fix: reject malformed `Host`/`X-Forwarded-Host` headers before URL construction to close a DPoP `htu` cross-endpoint replay bypass [\#244](https://github.com/auth0/node-oauth2-jwt-bearer/pull/244) ([tusharpandey13](https://github.com/tusharpandey13))
+
 ## [v1.9.0](https://github.com/auth0/node-oauth2-jwt-bearer/tree/v1.9.0) (2026-05-19)
 [Full Changelog](https://github.com/auth0/node-oauth2-jwt-bearer/compare/v1.8.0...v1.9.0)
 

--- a/packages/express-oauth2-jwt-bearer/package.json
+++ b/packages/express-oauth2-jwt-bearer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-oauth2-jwt-bearer",
   "description": "Authentication middleware for Express.js that validates JWT bearer access tokens.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "auth0/node-oauth2-jwt-bearer",


### PR DESCRIPTION
**Security**
- fix: reject malformed `Host`/`X-Forwarded-Host` headers before URL construction to close a DPoP `htu` cross-endpoint replay bypass [\#244](https://github.com/auth0/node-oauth2-jwt-bearer/pull/244) ([tusharpandey13](https://github.com/tusharpandey13))

## Summary

Patch release of `express-oauth2-jwt-bearer` (1.9.0 → 1.9.1) shipping the DPoP `htu` host-injection security fix.

- Bumps `express-oauth2-jwt-bearer` to `v1.9.1`
- Adds the `v1.9.1` CHANGELOG entry

## Depends on

- #244 — the fix itself. **Merge #244 first**, then merge this release PR. This PR contains only the version bump + changelog and is independently mergeable once #244 lands on `main`.

A GitHub Security Advisory should be published alongside this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)