### PR TITLE
docs: add CLAUDE.md agent guidelines for node-oauth2-jwt-bearer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AI Agent Guidelines for node-oauth2-jwt-bearer
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.
+
+This file exists so that non-Claude AI agents (Codex CLI, Gemini CLI, etc.) read the same instructions. All guidelines are maintained in a single place (`CLAUDE.md`) to avoid duplication and drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,151 @@
+# AI Agent Guidelines for node-oauth2-jwt-bearer
+
+This document provides context and guidelines for AI coding assistants working with the node-oauth2-jwt-bearer monorepo.
+
+## Your Role
+
+You are a TypeScript SDK engineer working on node-oauth2-jwt-bearer, the npm-workspaces monorepo behind `express-oauth2-jwt-bearer` — Express middleware that validates JWT bearer access tokens on the API/resource-server side. You write small, strongly-typed, fully-tested modules across three layered packages, treat the exported middleware and its options as the public contract, and keep token-validation correctness (signature, issuer, audience, algorithm, DPoP) non-negotiable.
+
+---
+
+## Working Principles
+
+Apply these on every task in this repo — they keep changes correct, small, and reviewable.
+
+- **Think before coding.** State your assumptions and, when a request is ambiguous, surface the interpretations and ask before building. Recommend a simpler approach when you see one. A clarifying question up front beats a wrong implementation.
+- **Simplicity first.** Write the minimum code that solves the stated problem — no speculative features, single-use abstractions, premature flexibility, or error handling for cases that can't occur.
+- **Surgical changes.** Touch only what the request requires. Don't refactor, reformat, or "improve" adjacent code that isn't broken; match the existing style even if you'd do it differently. Every changed line should trace directly to the request. Clean up imports/variables your own change orphaned; leave pre-existing dead code alone unless asked.
+- **Goal-driven execution.** Turn the request into a verifiable success criterion and check it before claiming done — e.g. "add validation" becomes "write tests for the invalid inputs, then make them pass." Don't report success you haven't verified.
+
+---
+
+## Project Overview
+
+**node-oauth2-jwt-bearer** is a monorepo whose published package, `express-oauth2-jwt-bearer`, is authentication middleware for Express.js that validates JWT bearer access tokens.
+
+- **Language:** TypeScript (compiled to CommonJS)
+- **Tech Stack:** npm workspaces (monorepo) · `jose` v4 (JWT/JWKS verification) · Express (peer, via the middleware package) · Jest + ts-jest · Rollup (published bundle) / `tsc` (internal packages)
+- **Package Manager:** npm (requires `npm >= 7.14` for workspaces)
+- **Minimum Platform Version:** Node.js — the published package supports `^12.19 || ^14.15 || ^16.13 || ^18.12 || ^20.2 || ^22.1 || ^24` (see each package's `engines`); CI builds/tests on Node 20/22/24
+- **Dependencies:** runtime `jose` 4 only · dev: Jest, ts-jest, nock, sinon, ESLint, Prettier, Rollup — see each `packages/*/package.json`
+
+---
+
+## Project Structure
+
+This is an **npm-workspaces monorepo**. The three library packages layer bottom-up; `express-oauth2-jwt-bearer` is the only published one.
+
+```
+.
+├── package.json          # Root: workspaces + aggregate scripts (test/lint/build run --workspaces)
+├── typedoc.js            # Generates docs/ from the express package's src
+├── docs/                 # Generated TypeDoc API output (do not hand-edit)
+└── packages/
+    ├── oauth2-bearer/            # (unpublished) extracts Bearer tokens from a request, RFC 6750 errors
+    │   └── src/                  # get-token.ts, errors.ts, index.ts
+    ├── access-token-jwt/         # (unpublished) verifies/decodes access-token JWTs; JWKS, DPoP, claim checks
+    │   └── src/                  # jwt-verifier.ts, token-verifier.ts, dpop-verifier.ts, discovery.ts, ...
+    ├── express-oauth2-jwt-bearer/# (PUBLISHED) the Express middleware — public API surface
+    │   ├── src/                  # index.ts (auth(), claim checks), resolve-host.ts
+    │   ├── README.md · EXAMPLES.md · .version   # docs + version source of truth
+    │   └── test/
+    └── examples/                 # (unpublished) playground / example API app
+```
+
+### Key Files
+
+| File | Why it matters |
+|------|----------------|
+| `packages/express-oauth2-jwt-bearer/src/index.ts` | Public API — `auth()` middleware + claim-check exports; the published contract |
+| `packages/access-token-jwt/src/jwt-verifier.ts` | Core JWT verification (issuer/audience/algorithm); largest module |
+| `packages/access-token-jwt/src/dpop-verifier.ts` | DPoP proof validation |
+| `packages/oauth2-bearer/src/get-token.ts` | Bearer-token extraction from requests |
+| `packages/*/package.json` | Per-package scripts, deps, and `engines`; lint/build config is per package |
+| `packages/express-oauth2-jwt-bearer/.version` | Version source of truth for the published package |
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run `npm test` and `npm run lint` (both aggregate across workspaces) before committing.
+- Follow existing TypeScript style and naming conventions (Prettier: single quotes, 80-col width).
+- Add unit tests for new functionality and keep the **100% coverage threshold** (the three library packages' `jest.config.js`) green; stub HTTP with `nock`, never real network.
+- Respect the package layering — `express-oauth2-jwt-bearer` depends on `access-token-jwt` which depends on `oauth2-bearer`; don't introduce upward or circular dependencies.
+- Keep each package's `dist/`-shipped types in sync with its runtime behavior — a changed option or export must update the TypeScript types in the same PR.
+- Keep `.version` in sync with the published package's `package.json` `"version"`.
+- Update the published package's `README.md` and `EXAMPLES.md` in the same PR when you change its public API, options, or supported integration patterns.
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never change or remove a public export, option, default, or error type on your own initiative; stop and ask the maintainer.
+- Adding new dependencies or bumping existing ones (runtime footprint is deliberately just `jose`).
+- Modifying public API signatures or the `AuthOptions` shape.
+- Changes to CI/CD configuration (`.github/workflows/`) or build config (`rollup.config.mjs`, `tsconfig.json`).
+- Modifying token-validation or security-critical code (signature/issuer/audience/algorithm checks, DPoP, JWKS handling).
+- Loosening or lowering the Jest coverage threshold.
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, tokens, or private keys.
+- Log tokens, decoded JWT payloads, DPoP proofs, or secrets.
+- Modify generated files by hand: `docs/` (TypeDoc output), `CHANGELOG.md`, `dist/`, coverage output, lock files.
+- Remove or skip failing tests, or lower coverage, without fixing the underlying cause.
+- Modify `node_modules/`.
+- Weaken token validation (accept `alg: none`, skip issuer/audience/expiry checks, disable DPoP verification) without explicit approval.
+
+---
+
+## Security Considerations
+
+This is an API-side JWT validator / resource-server library; the following are auto-detected and are non-negotiable:
+
+- **JWT verification:** `access-token-jwt` verifies signature, issuer, and audience via `jose`, discovering JWKS from the issuer's OAuth 2.0 Authorization Server Metadata (`discovery.ts`) or an explicit `jwksUri`. Supports asymmetric (JWKS/static public key) and symmetric (shared secret) issuers.
+- **Algorithms:** the verifier enforces an allowed-algorithms list; `none` is not accepted. Do not widen the algorithm set without review.
+- **DPoP:** sender-constrained tokens are validated in `dpop-verifier.ts`. Preserve proof checks (htu/htm/iat/jti, cnf/jkt binding).
+- **No telemetry:** this library only validates JWTs and fetches JWKS — it does **not** call Auth0 auth endpoints and sends **no** `Auth0-Client` telemetry. Do not add a telemetry header or client.
+- **Secrets:** symmetric secrets / issuer credentials come from caller config or env (`SECRET` for HS* signing, plus `ISSUER_BASE_URL`, `JWKS_URI`, `ISSUER`, `AUDIENCE`); never log or commit them. Note the `examples/` app generates a throwaway secret in source (`packages/examples/secret.ts`, `randomBytes(32)`) purely for its local demo — never do that in real code.
+
+---
+
+> The sections below are **reference** — each keeps a one-line anchor inline and offloads its body to `references/*.md` behind a linked pointer. Read a reference file only when your task needs it.
+
+## Commands
+
+```bash
+npm test            # run all workspace test suites (Jest, safe — HTTP is nocked)
+npm run lint        # lint all workspaces (ESLint --fix over each src)
+```
+
+See [references/commands.md](references/commands.md) for the full list (per-workspace commands, build, docs, examples playground). Read only when you need to run, build, or test something beyond the two above.
+
+## Testing
+
+Jest + ts-jest in the three library packages (`oauth2-bearer`, `access-token-jwt`, `express-oauth2-jwt-bearer`), run from the root with `npm test` (aggregates `--workspaces`). The `examples` workspace has no test suite (its `test`/`lint`/`build` scripts are no-ops). Tests are the safe default — no credentials, all HTTP stubbed with `nock`. Each library package enforces a **100% coverage threshold** (`jest.config.js`).
+
+See [references/testing.md](references/testing.md) for conventions, cross-package module mapping, mocking, and coverage. Read when writing or running tests.
+
+## Code Style
+
+TypeScript, CommonJS output. Prettier-enforced: **single quotes, 80-column print width**. ESLint uses `@typescript-eslint` recommended per package (`.eslintrc`), and `npm run lint` runs with `--fix`.
+
+See [references/code-style.md](references/code-style.md) for naming, patterns, and good/bad examples. Read before writing non-trivial new code.
+
+## Git Workflow
+
+Fork and branch off `main`; PRs must fill out the template, include tests for changed functionality, and pass lint. Run `npm test` and `npm run lint` before opening a PR against `main`.
+
+See [references/git-workflow.md](references/git-workflow.md) for full branch/commit/PR conventions. Read when preparing a commit or PR.
+
+## Common Pitfalls
+
+Top traps: keep the 100% coverage threshold green; HTTP in tests must be stubbed with `nock`; respect the package dependency layering; tests import sibling packages by name via Jest `moduleNameMapper`, so build order and path mapping matter.
+
+See [references/pitfalls.md](references/pitfalls.md) for the full list with fixes. Read when debugging unexpected behavior.
+
+## Docs Update Rules
+
+Treat docs as a first-class deliverable: a PR that changes the published package's public API, options, or integration patterns is not complete until its `README.md` / `EXAMPLES.md` are updated in the same PR.
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and the code-to-docs mapping. Read when changing public API, config, or examples.

--- a/references/code-style.md
+++ b/references/code-style.md
@@ -1,0 +1,48 @@
+# Code Style
+
+## Enforced tooling
+
+- **Prettier** (`packages/*/.prettierrc`): `singleQuote: true`, `printWidth: 80`.
+- **ESLint** (`packages/*/.eslintrc`, `root: true` per package): `@typescript-eslint/parser` + `eslint:recommended` + `plugin:@typescript-eslint/eslint-recommended` + `plugin:@typescript-eslint/recommended`. Only `express-oauth2-jwt-bearer/.eslintrc` adds a `rules` override — `@typescript-eslint/no-namespace: off` (that package augments the Express `Request` namespace); the other two packages have no `rules` block, so a `namespace` there would fail CI lint. `*.js` is ignored. `npm run lint` runs ESLint with `--fix`.
+- **TypeScript:** each package has its own `tsconfig.json` extending `@tsconfig/node12`; strict typing is expected.
+
+There is no separate CI `format` step — Prettier conventions are folded into what you write; ESLint is the CI-enforced gate (`lint` job).
+
+## Naming & module conventions
+
+- TypeScript compiled to CommonJS (`main: dist/index.js`, `types: dist/index.d.ts`).
+- File names are kebab-case (`get-token.ts`, `jwt-verifier.ts`, `dpop-verifier.ts`).
+- `camelCase` for functions/variables, `PascalCase` for types/interfaces/classes and error types (`InvalidTokenError`, `AuthOptions`).
+- Public exports flow through each package's `src/index.ts`; the middleware re-exports selected symbols from `access-token-jwt` (aliasing internals with a leading `_`).
+
+## Patterns used here
+
+- **Layered packages:** `oauth2-bearer` (transport/errors) → `access-token-jwt` (verification) → `express-oauth2-jwt-bearer` (Express glue). Keep responsibilities in the right layer; no upward/circular deps.
+- **Typed OAuth errors:** throw the RFC 6750 error hierarchy from `oauth2-bearer` (`InvalidRequestError`, `InvalidTokenError`, `InsufficientScopeError`, `UnauthorizedError`) so the middleware maps them to the correct 400/401/403 + `WWW-Authenticate`, rather than bare `Error`.
+- **Options-object API:** the middleware takes an `AuthOptions` object; claim checks (`claimEquals`, `claimIncludes`, `requiredScopes`, `scopeIncludesAny`) are composable factories.
+
+## Examples
+
+**✅ Good** — typed OAuth error, single quotes, option-driven:
+
+```typescript
+import { InvalidTokenError } from 'oauth2-bearer';
+
+export const requireAudience = (audience: string) => (payload: JWTPayload) => {
+  if (payload.aud !== audience) {
+    throw new InvalidTokenError('Unexpected token audience');
+  }
+};
+```
+
+**❌ Bad** — bare `Error`, double quotes, untyped:
+
+```typescript
+export function requireAudience(audience) {           // missing types
+  return (payload) => {
+    if (payload.aud !== audience) {
+      throw new Error("bad aud");                       // use the RFC 6750 error types; double quotes fail Prettier
+    }
+  };
+}
+```

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,0 +1,36 @@
+# Commands
+
+Full command reference for node-oauth2-jwt-bearer. Root scripts aggregate across workspaces; per-package scripts run one package. All map to scripts in `package.json` / `packages/*/package.json` and jobs in `.github/workflows/test.yml`.
+
+## Root (all workspaces)
+
+```bash
+npm install              # install all workspace deps (npm >= 7.14 required)
+npm test                 # run every package's test suite (npm test --workspaces)
+npm run lint             # lint every package (npm run lint --workspaces)
+npm run build            # build every package (npm run build --workspaces)
+npm run docs             # generate TypeDoc API docs into docs/ (typedoc --options typedoc.js)
+```
+
+## Per-package
+
+Run a single workspace with `--workspace=<name>`:
+
+```bash
+npm test  --workspace=express-oauth2-jwt-bearer     # jest test --coverage
+npm run lint  --workspace=access-token-jwt          # eslint --fix --ext .ts ./src
+npm run build --workspace=oauth2-bearer             # tsc (prebuild: rimraf dist)
+npm run dev   --workspace=packages/examples         # run the examples playground app
+```
+
+Build notes: `oauth2-bearer` and `access-token-jwt` compile with `tsc`; the published `express-oauth2-jwt-bearer` bundles with **Rollup** (`rollup -c`, `rollup.config.mjs`). Every package's `prebuild` runs `rimraf dist` first.
+
+## What CI runs
+
+`.github/workflows/test.yml`, gated on a build job (composite action `.github/actions/build`):
+
+- **build** — `npm run build` on Node 20 / 22 / 24
+- **unit** — `npm run test` on Node 20 / 22 / 24, then uploads coverage to Codecov
+- **lint** — `npm run lint`
+
+Other workflows: `codeql.yml`, `snyk.yml`, `rl-secure.yml` (security scans), `npm-release.yml` / `publish.yml` (release/publish — cut by the release process, not by an agent).

--- a/references/docs-update.md
+++ b/references/docs-update.md
@@ -1,0 +1,29 @@
+# Docs Update Rules
+
+Treat documentation as a first-class deliverable. A PR that adds or changes public API, options, or integration patterns is **not complete** until the relevant docs are updated in the same PR.
+
+## Tracked docs
+
+| Doc | Covers | Status |
+|-----|--------|--------|
+| `packages/express-oauth2-jwt-bearer/README.md` | Install, usage, `auth()` options, claim checks — the published package's primary docs | present |
+| `packages/express-oauth2-jwt-bearer/EXAMPLES.md` | Runnable code samples and integration patterns (scopes, claims, DPoP, custom issuers) | present |
+| `packages/examples/` | Playground / example API app exercising the middleware | present |
+| Root `README.md` | Monorepo overview + package table (published vs. internal) | present |
+
+> Not tracked here: `CHANGELOG.md` (cut by the release process, not agent-edited) and `docs/` (generated TypeDoc output). The internal packages' `README.md` files (`oauth2-bearer`, `access-token-jwt`) describe unpublished internals and are lower priority than the published package's docs.
+
+## When you change code, update these docs
+
+This is a library/SDK; the public surface is the exports of `packages/express-oauth2-jwt-bearer/src/index.ts` and the `AuthOptions` shape (much of it re-exported from `access-token-jwt`).
+
+| When this changes | Update these docs |
+|-------------------|-------------------|
+| `AuthOptions` / a middleware option added, removed, renamed, or default changed | express package `README.md` (options), `EXAMPLES.md` (affected samples) |
+| A public export added/removed/renamed (`auth`, `claimCheck`, `claimEquals`, `claimIncludes`, `requiredScopes`, `scopeIncludesAny`, error types) | express package `README.md` (usage), `EXAMPLES.md` |
+| Token-validation behavior (issuer/audience/algorithm, DPoP, claim checks) | express package `README.md`, `EXAMPLES.md` (auth examples) |
+| Install requirements / supported Node versions (`engines`) | express package `README.md` (install/requirements) |
+| A new integration pattern supported | `EXAMPLES.md` + the `packages/examples/` app when it warrants a runnable demo |
+| The set/status of monorepo packages | root `README.md` package table |
+
+> When you touch code that maps to a doc above, update that doc **in the same PR** — do not defer.

--- a/references/git-workflow.md
+++ b/references/git-workflow.md
@@ -1,0 +1,18 @@
+# Git Workflow
+
+## Branches
+
+- Default/base branch is `main`. Per `CONTRIBUTING.md`: fork the repo, create a well-named branch, and open a PR.
+- No branch-name linting is enforced; use a short descriptive name (e.g. `fix/dpop-iat-window`).
+
+## Before you commit
+
+- Run the checks CI enforces: `npm test` (all workspaces) and `npm run lint`. Code changes must be accompanied by tests covering the changed/added functionality, and coverage must stay at 100%.
+- No git hooks are configured in this repo; run the commands manually.
+
+## Commits & PRs
+
+- No commitlint/Conventional-Commits enforcement is configured; write clear, imperative commit subjects. (The `CHANGELOG.md` in the published package is produced by the release process — don't hand-edit it in feature PRs.)
+- Fill out the PR template completely (see `CONTRIBUTING.md` and Auth0's [general contributing guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)).
+- Open PRs against `main`. CI (`.github/workflows/test.yml`) must pass: build + unit tests on Node 20/22/24 and lint. Security workflows (CodeQL, Snyk, rl-secure) also run.
+- Security issues go through the [Responsible Disclosure Program](https://auth0.com/whitehat), not the public issue tracker.

--- a/references/pitfalls.md
+++ b/references/pitfalls.md
@@ -1,0 +1,17 @@
+# Common Pitfalls
+
+- **100% coverage is enforced.** Each of the three library packages' `jest.config.js` sets a `coverageThreshold.global` of 100% (branches/functions/lines/statements). A new branch or line without a covering test fails `npm test`. Add tests for every path, including error paths. (The `examples` workspace has no test suite — its scripts are no-ops.)
+
+- **Network is expected to be stubbed.** Tests use `nock` to intercept JWKS and OAuth discovery requests. A code path that makes an unmocked outbound call will hang or fail — register a `nock` interceptor for the well-known metadata and JWKS endpoints.
+
+- **Respect the package layering.** `express-oauth2-jwt-bearer` → `access-token-jwt` → `oauth2-bearer`. Don't add an upward dependency (a lower package importing a higher one) or a circular one. Shared logic belongs in the lowest package that needs it.
+
+- **Cross-package imports resolve to `src/`, not `dist/`.** Tests import siblings by package name (`access-token-jwt`, `oauth2-bearer`) via Jest `moduleNameMapper` + ts-jest `paths`. This works without building, but means a build-time-only mistake (e.g. a bad barrel export) may pass tests yet break the Rollup bundle — run `npm run build` when touching exports.
+
+- **`jwt-verifier.ts` and `token-verifier.ts` are large and security-critical.** Most validation logic (issuer resolution, algorithm allowlist, audience, DPoP wiring) lives here. Changes have wide blast radius and touch security — keep edits surgical, add targeted tests, and treat validation-weakening changes as Ask First.
+
+- **Only `express-oauth2-jwt-bearer` is published.** `oauth2-bearer` and `access-token-jwt` are `private: true` at `0.0.1` and shipped bundled into the published package. Don't document them as separately installable, and remember the published version source is `packages/express-oauth2-jwt-bearer/.version`.
+
+- **Two build tools.** Internal packages use `tsc`; the published package uses Rollup (`rollup.config.mjs`). When changing build behavior, edit the right one.
+
+- **No telemetry by design.** This is an API-side validator — it must not send an `Auth0-Client` header or call Auth0 auth endpoints. Don't "add telemetry" here.

--- a/references/testing.md
+++ b/references/testing.md
@@ -1,0 +1,25 @@
+# Testing
+
+## Framework & layout
+
+- **Jest + ts-jest** in the three library packages (`oauth2-bearer`, `access-token-jwt`, `express-oauth2-jwt-bearer` — each has a `jest.config.js`). The `examples` workspace has no test suite (its `test`/`lint`/`build` scripts are no-ops). Tests live in each library package's `test/` directory, written in TypeScript (`*.test.ts`). Config varies per package: `access-token-jwt` sets `testEnvironment: node` and `collectCoverageFrom: ['src/*']`; `oauth2-bearer` sets neither.
+- **Coverage:** each library package enforces a **100% threshold** on branches, functions, lines, and statements (`coverageThreshold.global` in `jest.config.js`). `jest-junit` writes results under `test-results/`.
+- **Run from root:** `npm test` aggregates `npm test --workspaces` (each package's `jest test --coverage`).
+
+The suite is unit-only and requires no credentials: external HTTP (JWKS/discovery endpoints) is stubbed with `nock`.
+
+## Running
+
+```bash
+npm test                                          # all packages
+npm test --workspace=express-oauth2-jwt-bearer    # one package
+npm test --workspace=access-token-jwt -- --coverage=false   # skip the coverage gate while iterating
+npx jest test/index.test.ts --workspace=...        # a single file (or cd into the package and run npx jest)
+```
+
+## Conventions
+
+- **Structure:** Jest `describe`/`it` blocks; assertions with Jest's built-in `expect`. `sinon` is available (in `access-token-jwt`) for stubs/spies where needed.
+- **HTTP stubbing:** use `nock` to intercept JWKS and OAuth Authorization Server Metadata (discovery) requests; tests drive the Express middleware with `got` against an ephemeral `express` server.
+- **Cross-package imports:** tests import sibling packages by their published name (`access-token-jwt`, `oauth2-bearer`), resolved via Jest `moduleNameMapper` and ts-jest `paths` to each sibling's `src/` — so you can run tests against source without building first. Test helpers are shared across packages (e.g. `access-token-jwt/test/helpers` `createJwt`).
+- **Token fixtures:** JWTs are minted in-test (helper `createJwt`) with test keys — never real tokens.


### PR DESCRIPTION
## Summary

Adds AI-agent guidelines for node-oauth2-jwt-bearer — a lean, guardrail-first `CLAUDE.md` plus a thin `AGENTS.md` that points to it, generated by the `generating-claude-md` skill and validated against the repo. This is a monorepo, so per the skill's current single-root-file behavior it ships **one root `CLAUDE.md`** covering the repo and its packages.

- **`CLAUDE.md`** (151 lines) — persona, working principles, project overview/structure, three-tier Boundaries, Security, and one-line anchors into `references/`.
- **`AGENTS.md`** — imports `@./CLAUDE.md` so non-Claude tools (Codex CLI, Gemini CLI) share the same guidance.
- **`references/*.md`** — full detail offloaded on demand: `commands`, `testing`, `code-style`, `git-workflow`, `pitfalls`, `docs-update`.

## What detection surfaced (node-oauth2-jwt-bearer specific)

- **npm-workspaces monorepo** — three layered packages (`oauth2-bearer` → `access-token-jwt` → `express-oauth2-jwt-bearer`) plus `examples`; only `express-oauth2-jwt-bearer` (v1.9.1) is published. Structure section and root scripts (`test`/`lint`/`build` run `--workspaces`) reflect this.
- **API-side JWT validator → no telemetry** — this library only verifies JWTs and fetches JWKS; it sends no `Auth0-Client` header. Per the skill's telemetry rules (shape 4), the telemetry boundary is **intentionally omitted**, and Security says so explicitly.
- **Security posture** — signature/issuer/audience verification via `jose`, an enforced algorithm allowlist (`none` rejected), and DPoP proof validation (`dpop-verifier.ts`) → documented in Security, not the persona.
- **Jest with a 100% coverage threshold** (`jest.config.js`, all packages) → surfaced as an Always-Do boundary and a pitfall; lowering it is Ask-First.
- **Cross-package testing** — tests import siblings by name via Jest `moduleNameMapper` + ts-jest `paths` (resolve to `src/`, no build needed) → captured in testing + pitfalls.
- **Two build tools** — internal packages use `tsc`; the published package bundles with **Rollup** (`rollup.config.mjs`) → noted in commands + pitfalls.
- **Code style** — per-package `.eslintrc` (`@typescript-eslint` recommended) + Prettier (`singleQuote`, `printWidth: 80`); RFC 6750 typed error hierarchy (`InvalidTokenError`, `InsufficientScopeError`, ...) as the error convention.
- **Docs mapping** (library shape) — the published package's exports/options map to its `README.md` / `EXAMPLES.md` / `examples/`; `CHANGELOG.md` and generated `docs/` (TypeDoc) intentionally not tracked.

## Validation

Filesystem validation pass: every cited path, every `package.json` script / CI job, and every `references/*.md` pointer (6/6) verified to exist in the repo — no invented tooling.
