### PR TITLE
docs: add Anonymous Sessions guidance for express-oauth2-jwt-bearer

### DIFF
--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -19,6 +19,10 @@
   - [Matching a specific value](#matching-a-specific-value)
   - [Matching multiple values](#matching-multiple-values)
   - [Matching custom logic](#matching-custom-logic)
+- [Anonymous Sessions](#anonymous-sessions)
+  - [Block all anonymous callers globally](#block-all-anonymous-callers-globally)
+  - [Block anonymous callers on specific routes](#block-anonymous-callers-on-specific-routes)
+  - [Accept anonymous callers and branch in the handler](#accept-anonymous-callers-and-branch-in-the-handler)
 
 
 ## DPoP Authentication
@@ -520,4 +524,60 @@ app.get('/api/admin/edit',
       // ...
    }
 );
+```
+
+## Anonymous Sessions
+
+> **Auth0-specific feature.** Requires the Anonymous Sessions add-on to be enabled on your Auth0 tenant.
+
+Auth0 Anonymous Sessions issues standard JWT Bearer tokens to unauthenticated users. These tokens are validated by this SDK exactly like any other access token. The only distinguishing characteristic is that `sub` starts with `anon@` (e.g. `anon@abc123def456`).
+
+By default, a valid anonymous token passes `auth()` just like an authenticated user's token. Use the patterns below to control access based on whether the caller is anonymous.
+
+### Block all anonymous callers globally
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuerBaseURL: 'https://YOUR_DOMAIN',
+    audience: 'https://api.example.com',
+    validators: {
+      sub: (sub) => !sub.startsWith('anon@'),
+    },
+  })
+);
+```
+
+### Block anonymous callers on specific routes
+
+```js
+const { auth, claimCheck } = require('express-oauth2-jwt-bearer');
+
+app.use(auth({
+  issuerBaseURL: 'https://YOUR_DOMAIN',
+  audience: 'https://api.example.com',
+}));
+
+app.get('/checkout',
+  claimCheck((payload) => !payload.sub?.startsWith('anon@')),
+  (req, res) => { /* authenticated callers only */ }
+);
+```
+
+### Accept anonymous callers and branch in the handler
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(auth({
+  issuerBaseURL: 'https://YOUR_DOMAIN',
+  audience: 'https://api.example.com',
+}));
+
+app.get('/cart', (req, res) => {
+  const isAnonymous = req.auth.payload.sub?.startsWith('anon@');
+  // serve differently based on whether the caller is anonymous
+});
 ```

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -133,6 +133,12 @@ To learn how to:
 
 **See [DPoP examples in `EXAMPLES.md`](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/EXAMPLES.md#dpop-authentication-early-access)**
 
+#### Anonymous Sessions
+
+Auth0 Anonymous Sessions issues standard JWT Bearer tokens to unauthenticated users. The `sub` claim starts with `anon@`, which you can use to accept, reject, or branch on anonymous callers.
+
+**See [Anonymous Sessions examples in `EXAMPLES.md`](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/EXAMPLES.md#anonymous-sessions)**
+
 
 ### Security Headers
 


### PR DESCRIPTION
## Summary

Auth0 Anonymous Sessions issues standard JWT Bearer tokens to unauthenticated users. These tokens pass through `express-oauth2-jwt-bearer` validation unchanged — the only distinguishing characteristic is that `sub` starts with `anon@`.

This PR documents the three patterns developers need to handle anonymous callers using primitives already available in the SDK:

- **Block all anonymous callers globally** — via the `validators.sub` option on `auth()`
- **Block anonymous callers on specific routes** — via `claimCheck()`
- **Accept anonymous callers and branch in the handler** — via `req.auth.payload.sub`

## Changes

- `EXAMPLES.md` — new Anonymous Sessions section with TOC entry and the three code patterns
- `README.md` — brief callout under the SDK configuration section linking to the examples