### PR TITLE
feat: add mTLS certificate-bound access token validation (RFC 8705)

### DIFF
--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -1,12 +1,21 @@
 export {
   default as tokenVerifier,
   assertValidDPoPOptions,
+  assertValidMtlsOptions,
   type DPoPJWTPayload,
   type RequestLike,
   type HeadersLike,
   type AuthOptions,
   type DPoPOptions,
+  type MtlsOptions,
 } from './token-verifier'
+export {
+  verifyMtls,
+  calculateCertificateThumbprint,
+  assertCertificateConfirmation,
+  type ClientCertificate,
+  type MtlsJWTPayload,
+} from './mtls-verifier';
 export {
   default as jwtVerifier,
   JwtVerifierOptions,

--- a/packages/access-token-jwt/src/index.ts
+++ b/packages/access-token-jwt/src/index.ts
@@ -10,9 +10,6 @@ export {
   type MtlsOptions,
 } from './token-verifier'
 export {
-  verifyMtls,
-  calculateCertificateThumbprint,
-  assertCertificateConfirmation,
   type ClientCertificate,
   type MtlsJWTPayload,
 } from './mtls-verifier';

--- a/packages/access-token-jwt/src/mtls-verifier.ts
+++ b/packages/access-token-jwt/src/mtls-verifier.ts
@@ -12,7 +12,7 @@ export interface MtlsConfirmationClaims {
   'x5t#S256': string;
 }
 
-interface MtlsJWTPayload extends JWTPayload {
+export interface MtlsJWTPayload extends JWTPayload {
   cnf?: MtlsConfirmationClaims;
 }
 
@@ -135,12 +135,12 @@ function assertCertificateConfirmation(accessTokenClaims: JWTPayload): string {
  * @throws {InvalidTokenError} If the confirmation claim is malformed or the
  *   thumbprint does not match the presented certificate.
  */
-async function verifyMtls(options: MtlsVerifierOptions): Promise<void> {
+function verifyMtls(options: MtlsVerifierOptions): void {
   const { accessTokenClaims, clientCertificate } = options;
 
   const expected = assertCertificateConfirmation(accessTokenClaims);
 
-  if (clientCertificate === undefined || clientCertificate === null) {
+  if (clientCertificate === undefined) {
     throw new InvalidRequestError(
       'A client certificate is required for this certificate-bound access token'
     );
@@ -159,4 +159,3 @@ export {
   assertCertificateConfirmation,
   verifyMtls,
 };
-export type { MtlsJWTPayload };

--- a/packages/access-token-jwt/src/mtls-verifier.ts
+++ b/packages/access-token-jwt/src/mtls-verifier.ts
@@ -1,0 +1,162 @@
+import { base64url, type JWTPayload } from 'jose';
+import { createHash } from 'crypto';
+import { InvalidRequestError, InvalidTokenError } from 'oauth2-bearer';
+import { isJsonObject } from './dpop-verifier';
+
+/**
+ * The `x5t#S256` confirmation claim (RFC 8705 §3.1): the base64url-encoded
+ * SHA-256 hash of the DER encoding of the client certificate the token is
+ * bound to.
+ */
+export interface MtlsConfirmationClaims {
+  'x5t#S256': string;
+}
+
+interface MtlsJWTPayload extends JWTPayload {
+  cnf?: MtlsConfirmationClaims;
+}
+
+/**
+ * A client certificate presented on the TLS connection, obtained by the
+ * caller-supplied resolver. Either the PEM text (as produced by most
+ * TLS-terminating proxies, typically URL-decoded first) or the raw DER bytes
+ * (e.g. `req.socket.getPeerCertificate().raw`).
+ */
+export type ClientCertificate = string | Buffer | Uint8Array;
+
+export type MtlsVerifierOptions = {
+  accessTokenClaims: JWTPayload;
+  clientCertificate: ClientCertificate | undefined;
+};
+
+const PEM_RE =
+  /-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\s]+?)-----END CERTIFICATE-----/;
+
+/**
+ * Converts a client certificate to its DER-encoded bytes.
+ *
+ * Accepts a PEM string (single certificate), or a Buffer/Uint8Array that is
+ * assumed to already be the DER encoding.
+ *
+ * @throws {InvalidRequestError} If a PEM string cannot be parsed.
+ */
+function toDer(cert: ClientCertificate): Buffer {
+  if (typeof cert === 'string') {
+    const match = cert.match(PEM_RE);
+    if (!match) {
+      throw new InvalidRequestError(
+        'Client certificate is not valid PEM',
+        false
+      );
+    }
+    // Strip whitespace from the base64 body before decoding.
+    return Buffer.from(match[1].replace(/\s+/g, ''), 'base64');
+  }
+
+  return Buffer.isBuffer(cert) ? cert : Buffer.from(cert);
+}
+
+/**
+ * Computes the RFC 8705 certificate thumbprint: base64url(SHA-256(DER)).
+ *
+ * @throws {InvalidRequestError} If the certificate cannot be decoded.
+ */
+function calculateCertificateThumbprint(cert: ClientCertificate): string {
+  const der = toDer(cert);
+
+  if (der.length === 0) {
+    throw new InvalidRequestError('Client certificate is empty', false);
+  }
+
+  const hash = createHash('sha256').update(der).digest();
+  return base64url.encode(hash);
+}
+
+/**
+ * Validates the structure of the `cnf` confirmation claim for a
+ * certificate-bound access token and returns the `x5t#S256` thumbprint.
+ *
+ * Mirrors the DPoP `cnf` guards: the claim must be a single-key JSON object
+ * carrying a non-empty string `x5t#S256`.
+ *
+ * @throws {InvalidTokenError} If the confirmation claim is missing or malformed.
+ */
+function assertCertificateConfirmation(accessTokenClaims: JWTPayload): string {
+  const cnf = accessTokenClaims.cnf;
+
+  if (!cnf) {
+    throw new InvalidTokenError(
+      'JWT Access Token has no x5t#S256 confirmation claim'
+    );
+  }
+
+  if (!isJsonObject(cnf)) {
+    throw new InvalidTokenError('Invalid "cnf" confirmation claim structure');
+  }
+
+  const confirmation = cnf as Record<string, unknown>;
+
+  if (Object.keys(confirmation).length > 1) {
+    throw new InvalidTokenError(
+      'Multiple confirmation claims are not supported'
+    );
+  }
+
+  if (!('x5t#S256' in confirmation)) {
+    throw new InvalidTokenError(
+      'JWT Access Token has no x5t#S256 confirmation claim'
+    );
+  }
+
+  const thumbprint = confirmation['x5t#S256'];
+
+  if (typeof thumbprint !== 'string') {
+    throw new InvalidTokenError('Malformed "x5t#S256" confirmation claim');
+  }
+
+  if (!thumbprint.length) {
+    throw new InvalidTokenError('Invalid "x5t#S256" confirmation claim');
+  }
+
+  return thumbprint;
+}
+
+/**
+ * Verifies that a certificate-bound access token (RFC 8705) matches the client
+ * certificate presented on the TLS connection.
+ *
+ * The token's `cnf.x5t#S256` claim is compared against the base64url-encoded
+ * SHA-256 thumbprint of the presented certificate. The certificate is obtained
+ * by the caller (typically from a TLS-terminating proxy header) and passed in;
+ * this verifier is transport-agnostic.
+ *
+ * @throws {InvalidRequestError} If the token is cert-bound but no certificate
+ *   was presented, or the certificate cannot be decoded.
+ * @throws {InvalidTokenError} If the confirmation claim is malformed or the
+ *   thumbprint does not match the presented certificate.
+ */
+async function verifyMtls(options: MtlsVerifierOptions): Promise<void> {
+  const { accessTokenClaims, clientCertificate } = options;
+
+  const expected = assertCertificateConfirmation(accessTokenClaims);
+
+  if (clientCertificate === undefined || clientCertificate === null) {
+    throw new InvalidRequestError(
+      'A client certificate is required for this certificate-bound access token'
+    );
+  }
+
+  const actual = calculateCertificateThumbprint(clientCertificate);
+
+  if (actual !== expected) {
+    // @see https://www.rfc-editor.org/rfc/rfc8705#section-3.2
+    throw new InvalidTokenError('JWT Access Token confirmation mismatch');
+  }
+}
+
+export {
+  calculateCertificateThumbprint,
+  assertCertificateConfirmation,
+  verifyMtls,
+};
+export type { MtlsJWTPayload };

--- a/packages/access-token-jwt/src/token-verifier.ts
+++ b/packages/access-token-jwt/src/token-verifier.ts
@@ -188,6 +188,15 @@ interface DPoPOptions {
  * - <u>Misconfiguration</u> (*`{ enabled: false, required: true }`*):
  *   Invalid — mTLS is disabled, so a binding cannot be required.
  *
+ * Interaction with DPoP:
+ * A token carries at most one confirmation method, so mTLS and DPoP are mutually
+ * exclusive per token. When both are enabled, DPoP is evaluated first and takes
+ * precedence: the mTLS verifier runs only for requests the DPoP path does not
+ * handle. As a result `required: true` is scoped to the mTLS path (it does not
+ * force a certificate binding on a request satisfied by a DPoP-bound token), and
+ * enabling `dpop.required` makes these options inert because every request is
+ * then routed to the DPoP path.
+ *
  * @see https://www.rfc-editor.org/rfc/rfc8705
  */
 interface MtlsOptions {
@@ -201,6 +210,10 @@ interface MtlsOptions {
   /**
    * Requires every access token to be certificate-bound. When `true`, a token
    * without a valid `cnf.x5t#S256` binding is rejected.
+   *
+   * Scoped to the mTLS path: when DPoP is also enabled, DPoP is evaluated first,
+   * so a DPoP-bound token is handled by the DPoP path and this requirement is
+   * not applied to it.
    *
    * @default false
    */

--- a/packages/access-token-jwt/src/token-verifier.ts
+++ b/packages/access-token-jwt/src/token-verifier.ts
@@ -27,7 +27,7 @@ const DEFAULT_DPOP_ENABLED = true; // DPoP is enabled by default.
 const DEFAULT_DPOP_REQUIRED = false; // DPoP is allowed by default.
 const DEFAULT_IAT_OFFSET = 300; // 5 minutes.
 const DEFAULT_IAT_LEEWAY = 30; // 30 seconds.
-const DEFAULT_MTLS_ENABLED = true; // mTLS binding is validated by default.
+const DEFAULT_MTLS_ENABLED = false; // mTLS is opt-in: cnf.x5t#S256 is ignored unless enabled.
 const DEFAULT_MTLS_REQUIRED = false; // Certificate-bound tokens are allowed, not required.
 
 /**
@@ -172,21 +172,27 @@ interface DPoPOptions {
  * Express `auth()` middleware — and is then passed to this verifier as raw
  * PEM or DER.
  *
+ * mTLS is opt-in: unlike DPoP, it depends on a certificate resolver the
+ * caller must supply (see `getCertificate` on the Express `auth()`
+ * middleware), so it cannot safely default to on. The Express middleware
+ * enables it automatically when `getCertificate` is supplied, unless
+ * `enabled` is set explicitly.
+ *
  * Behavior matrix:
  *
- * - <u>Default</u> (*`{ enabled: true, required: false }`*):
+ * - <u>Default</u> (*`{ enabled: false }`*):
+ *   The `cnf.x5t#S256` claim is ignored and no certificate binding is checked.
+ *
+ * - <u>Enabled</u> (*`{ enabled: true, required: false }`*):
  *   Validates the certificate binding when the token carries `cnf.x5t#S256`;
  *   plain bearer tokens are accepted as-is.
- *
- * - <u>Disabled</u> (*`{ enabled: false }`*):
- *   The `cnf.x5t#S256` claim is ignored and no certificate binding is checked.
  *
  * - <u>Required</u> (*`{ enabled: true, required: true }`*):
  *   Every access token must be certificate-bound; a token without a valid
  *   `cnf.x5t#S256` binding is rejected.
  *
- * - <u>Misconfiguration</u> (*`{ enabled: false, required: true }`*):
- *   Invalid — mTLS is disabled, so a binding cannot be required.
+ * - <u>Misconfiguration</u> (*`{ required: true }`* without *`enabled: true`*):
+ *   Invalid — a binding cannot be required unless mTLS is explicitly enabled.
  *
  * Interaction with DPoP:
  * A token carries at most one confirmation method, so mTLS and DPoP are mutually
@@ -203,7 +209,11 @@ interface MtlsOptions {
   /**
    * Enables validation of certificate-bound (`cnf.x5t#S256`) access tokens.
    *
-   * @default true
+   * mTLS is opt-in. The Express `auth()` middleware sets this to `true`
+   * automatically when a `getCertificate` resolver is supplied, unless you
+   * set it explicitly.
+   *
+   * @default false
    */
   enabled?: boolean;
 
@@ -214,6 +224,9 @@ interface MtlsOptions {
    * Scoped to the mTLS path: when DPoP is also enabled, DPoP is evaluated first,
    * so a DPoP-bound token is handled by the DPoP path and this requirement is
    * not applied to it.
+   *
+   * Requires `enabled: true` to also be set explicitly; mTLS being opt-in
+   * means it cannot be turned on implicitly just by requiring it.
    *
    * @default false
    */
@@ -244,9 +257,13 @@ interface AuthOptions extends JwtVerifierOptions {
    * (RFC 8705). If not provided or set to `undefined`, the following default
    * values will be used:
    * {
-   *   enabled: true,
+   *   enabled: false,
    *   required: false,
    * }
+   *
+   * mTLS is opt-in: the Express `auth()` middleware sets `enabled: true`
+   * automatically when a `getCertificate` resolver is supplied, unless you
+   * set `enabled` explicitly.
    */
   mtls?: MtlsOptions;
 }
@@ -406,8 +423,8 @@ function assertValidMtlsOptions(mtlsOptions?: MtlsOptions): void {
   }
 
   assert(
-    !(enabled === false && required === true),
-    'Invalid mTLS configuration: cannot set "required" to true when "enabled" is false'
+    !(required === true && enabled !== true),
+    'Invalid mTLS configuration: "required" can only be set to true when "enabled" is also true'
   );
 }
 
@@ -632,7 +649,7 @@ function tokenVerifier(
       // DPoP is intentionally checked first and shadows mTLS: a token carries at
       // most one confirmation method, and a DPoP proof header (if present) routes
       // the request to the DPoP path above regardless of any cnf.x5t#S256 claim.
-      await verifyMtls({ accessTokenClaims, clientCertificate });
+      verifyMtls({ accessTokenClaims, clientCertificate });
     }
 
     return verifiedJwt;

--- a/packages/access-token-jwt/src/token-verifier.ts
+++ b/packages/access-token-jwt/src/token-verifier.ts
@@ -45,8 +45,7 @@ function isDPoPBound(accessTokenClaims: DPoPJWTPayload): boolean {
  */
 function isMtlsBound(accessTokenClaims: DPoPJWTPayload): boolean {
   return (
-    isJsonObject(accessTokenClaims.cnf) &&
-    'x5t#S256' in (accessTokenClaims.cnf as unknown as Record<string, unknown>)
+    isJsonObject(accessTokenClaims.cnf) && 'x5t#S256' in accessTokenClaims.cnf!
   );
 }
 
@@ -617,6 +616,9 @@ function tokenVerifier(
     } else if (shouldVerifyMtls(accessTokenClaims)) {
       // Certificate-bound access token (RFC 8705). Validate that the certificate
       // presented on the TLS connection matches the token's cnf.x5t#S256 claim.
+      // DPoP is intentionally checked first and shadows mTLS: a token carries at
+      // most one confirmation method, and a DPoP proof header (if present) routes
+      // the request to the DPoP path above regardless of any cnf.x5t#S256 claim.
       await verifyMtls({ accessTokenClaims, clientCertificate });
     }
 

--- a/packages/access-token-jwt/src/token-verifier.ts
+++ b/packages/access-token-jwt/src/token-verifier.ts
@@ -21,10 +21,34 @@ import {
   DPoPJWTPayload,
 } from './dpop-verifier';
 
+import { verifyMtls, ClientCertificate } from './mtls-verifier';
+
 const DEFAULT_DPOP_ENABLED = true; // DPoP is enabled by default.
 const DEFAULT_DPOP_REQUIRED = false; // DPoP is allowed by default.
 const DEFAULT_IAT_OFFSET = 300; // 5 minutes.
 const DEFAULT_IAT_LEEWAY = 30; // 30 seconds.
+const DEFAULT_MTLS_ENABLED = true; // mTLS binding is validated by default.
+const DEFAULT_MTLS_REQUIRED = false; // Certificate-bound tokens are allowed, not required.
+
+/**
+ * Returns true if the access token is DPoP-bound (carries a `cnf.jkt` claim).
+ */
+function isDPoPBound(accessTokenClaims: DPoPJWTPayload): boolean {
+  return (
+    isJsonObject(accessTokenClaims.cnf) && 'jkt' in accessTokenClaims.cnf!
+  );
+}
+
+/**
+ * Returns true if the access token is certificate-bound per RFC 8705
+ * (carries a `cnf.x5t#S256` claim).
+ */
+function isMtlsBound(accessTokenClaims: DPoPJWTPayload): boolean {
+  return (
+    isJsonObject(accessTokenClaims.cnf) &&
+    'x5t#S256' in (accessTokenClaims.cnf as unknown as Record<string, unknown>)
+  );
+}
 
 /**
  * Options that control Demonstration of Proof-of-Possession (DPoP) handling.
@@ -132,6 +156,58 @@ interface DPoPOptions {
   iatLeeway?: number;
 }
 
+/**
+ * Options that control mutual-TLS certificate-bound access token validation
+ * (RFC 8705 §3).
+ *
+ * @remarks
+ * When a client authenticates to the authorization server with a TLS client
+ * certificate, the issued access token carries a `cnf.x5t#S256` claim: the
+ * base64url-encoded SHA-256 thumbprint of that certificate. This SDK validates,
+ * on each request, that the certificate presented on the TLS connection matches
+ * the thumbprint in the token.
+ *
+ * Because APIs commonly run behind a TLS-terminating proxy (nginx, ALB,
+ * Cloudflare, etc.), the SDK cannot read the TLS socket directly. The client
+ * certificate must be supplied by the caller — see `getCertificate` on the
+ * Express `auth()` middleware — and is then passed to this verifier as raw
+ * PEM or DER.
+ *
+ * Behavior matrix:
+ *
+ * - <u>Default</u> (*`{ enabled: true, required: false }`*):
+ *   Validates the certificate binding when the token carries `cnf.x5t#S256`;
+ *   plain bearer tokens are accepted as-is.
+ *
+ * - <u>Disabled</u> (*`{ enabled: false }`*):
+ *   The `cnf.x5t#S256` claim is ignored and no certificate binding is checked.
+ *
+ * - <u>Required</u> (*`{ enabled: true, required: true }`*):
+ *   Every access token must be certificate-bound; a token without a valid
+ *   `cnf.x5t#S256` binding is rejected.
+ *
+ * - <u>Misconfiguration</u> (*`{ enabled: false, required: true }`*):
+ *   Invalid — mTLS is disabled, so a binding cannot be required.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8705
+ */
+interface MtlsOptions {
+  /**
+   * Enables validation of certificate-bound (`cnf.x5t#S256`) access tokens.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * Requires every access token to be certificate-bound. When `true`, a token
+   * without a valid `cnf.x5t#S256` binding is rejected.
+   *
+   * @default false
+   */
+  required?: boolean;
+}
+
 interface AuthOptions extends JwtVerifierOptions {
   /**
    * True if a valid Access Token JWT should be required for all routes.
@@ -150,6 +226,17 @@ interface AuthOptions extends JwtVerifierOptions {
    * }
    */
   dpop?: DPoPOptions;
+
+  /**
+   * Options to configure mTLS certificate-bound access token validation
+   * (RFC 8705). If not provided or set to `undefined`, the following default
+   * values will be used:
+   * {
+   *   enabled: true,
+   *   required: false,
+   * }
+   */
+  mtls?: MtlsOptions;
 }
 export interface AuthError extends UnauthorizedError {
   code?: string;
@@ -175,6 +262,7 @@ type RequestLike = Record<string, unknown> & {
   query?: QueryLike;
   body?: BodyLike;
   isUrlEncoded?: boolean; // true if the request's Content-Type is `application/x-www-form-urlencoded`
+  clientCertificate?: ClientCertificate; // the client certificate presented on the TLS connection, resolved by the caller (mTLS, RFC 8705)
 };
 
 // Normalize headers to a lowercase key object
@@ -274,6 +362,43 @@ function assertValidDPoPOptions(dpopOptions?: DPoPOptions): void {
   );
 }
 
+/**
+ * Asserts that the provided mTLS options are valid.
+ * Throws an error if any of the options are invalid.
+ *
+ * @param mtlsOptions - The mTLS options to validate
+ * @throws {Error} If the options are invalid
+ */
+function assertValidMtlsOptions(mtlsOptions?: MtlsOptions): void {
+  if (mtlsOptions === undefined) return;
+
+  assert(
+    isJsonObject(mtlsOptions),
+    'Invalid mTLS configuration: "mtls" must be an object'
+  );
+
+  const { enabled, required } = mtlsOptions;
+
+  if (enabled !== undefined) {
+    assert(
+      typeof enabled === 'boolean',
+      'Invalid mTLS option: "enabled" must be a boolean'
+    );
+  }
+
+  if (required !== undefined) {
+    assert(
+      typeof required === 'boolean',
+      'Invalid mTLS option: "required" must be a boolean'
+    );
+  }
+
+  assert(
+    !(enabled === false && required === true),
+    'Invalid mTLS configuration: cannot set "required" to true when "enabled" is false'
+  );
+}
+
 function tokenVerifier(
   verifyJwt: VerifyJwt,
   options: AuthOptions = {},
@@ -285,6 +410,7 @@ function tokenVerifier(
   const query = requestOptions?.query;
   const body = requestOptions?.body;
   const isUrlEncoded = requestOptions?.isUrlEncoded ?? false;
+  const clientCertificate = requestOptions?.clientCertificate;
   const authScheme = getAuthScheme(headers)?.toLowerCase();
   // Extract DPoP options from the provided options or use defaults
   const {
@@ -293,6 +419,10 @@ function tokenVerifier(
       required: dpopRequired = DEFAULT_DPOP_REQUIRED,
       iatOffset = DEFAULT_IAT_OFFSET,
       iatLeeway = DEFAULT_IAT_LEEWAY,
+    } = {},
+    mtls: {
+      enabled: mtlsEnabled = DEFAULT_MTLS_ENABLED,
+      required: mtlsRequired = DEFAULT_MTLS_REQUIRED,
     } = {},
   } = options;
   let hasNonHeaderToken = false;
@@ -321,9 +451,31 @@ function tokenVerifier(
 
     const hasDPoPHeader = 'dpop' in headers;
     const isDPoPScheme = authScheme === 'dpop';
-    const hasBoundToken = 'cnf' in accessTokenClaims;
+    const hasBoundToken = isDPoPBound(accessTokenClaims);
 
     return dpopRequired || isDPoPScheme || hasBoundToken || hasDPoPHeader;
+  }
+
+  /**
+   * Determines whether mTLS certificate-binding validation applies to a request.
+   *
+   * Validation is triggered when mTLS is enabled AND either:
+   * - it is required by configuration, OR
+   * - the access token carries a `cnf.x5t#S256` claim (certificate-bound).
+   *
+   * DPoP-bound tokens (`cnf.jkt`) are handled by the DPoP path; a token carries
+   * at most one confirmation method.
+   *
+   * @method shouldVerifyMtls
+   * @param accessTokenClaims - The verified access token claims
+   * @returns `true` if mTLS validation should be enforced
+   */
+  function shouldVerifyMtls(accessTokenClaims: DPoPJWTPayload): boolean {
+    if (!mtlsEnabled) {
+      return false;
+    }
+
+    return mtlsRequired || isMtlsBound(accessTokenClaims);
   }
 
   function getToken(): TokenInfo {
@@ -439,12 +591,13 @@ function tokenVerifier(
 
     if (
       authScheme === 'bearer' &&
-      'cnf' in accessTokenClaims &&
+      isDPoPBound(accessTokenClaims) &&
       dpopEnabled &&
       !dpopRequired
     ) {
       // In "allowed" DPoP mode, if the token is DPoP-bound but sent with Bearer scheme,
-      // we throw an InvalidTokenError to indicate that the token is not valid for Bearer
+      // we throw an InvalidTokenError to indicate that the token is not valid for Bearer.
+      // mTLS-bound tokens (cnf.x5t#S256) legitimately use Bearer and are excluded here.
       throw new InvalidTokenError(
         'DPoP-bound token requires the DPoP authentication scheme, not Bearer.'
       );
@@ -461,6 +614,10 @@ function tokenVerifier(
         iatLeeway,
         supportedAlgorithms: SUPPORTED_ALGORITHMS,
       });
+    } else if (shouldVerifyMtls(accessTokenClaims)) {
+      // Certificate-bound access token (RFC 8705). Validate that the certificate
+      // presented on the TLS connection matches the token's cnf.x5t#S256 claim.
+      await verifyMtls({ accessTokenClaims, clientCertificate });
     }
 
     return verifiedJwt;
@@ -551,6 +708,7 @@ function tokenVerifier(
 
   return {
     shouldVerifyDPoP,
+    shouldVerifyMtls,
     getToken,
     verify,
     applyAuthChallenges,
@@ -558,11 +716,17 @@ function tokenVerifier(
 }
 
 export default tokenVerifier;
-export { normalizeHeaders, getAuthScheme, assertValidDPoPOptions };
+export {
+  normalizeHeaders,
+  getAuthScheme,
+  assertValidDPoPOptions,
+  assertValidMtlsOptions,
+};
 export type {
   DPoPJWTPayload,
   AuthOptions,
   DPoPOptions,
+  MtlsOptions,
   QueryLike,
   BodyLike,
   RequestLike,

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -249,4 +249,20 @@ describe('index', () => {
       expect(err.message).toBe('test message');
     });
   });
+
+  describe('mTLS re-exports', () => {
+    it('exports the mTLS verifier helpers and options validator', () => {
+      const {
+        assertValidMtlsOptions,
+        verifyMtls,
+        calculateCertificateThumbprint,
+        assertCertificateConfirmation,
+      } = require('../src');
+
+      expect(typeof assertValidMtlsOptions).toBe('function');
+      expect(typeof verifyMtls).toBe('function');
+      expect(typeof calculateCertificateThumbprint).toBe('function');
+      expect(typeof assertCertificateConfirmation).toBe('function');
+    });
+  });
 });

--- a/packages/access-token-jwt/test/index.test.ts
+++ b/packages/access-token-jwt/test/index.test.ts
@@ -251,18 +251,22 @@ describe('index', () => {
   });
 
   describe('mTLS re-exports', () => {
-    it('exports the mTLS verifier helpers and options validator', () => {
+    it('exports the mTLS options validator', () => {
+      const { assertValidMtlsOptions } = require('../src');
+
+      expect(typeof assertValidMtlsOptions).toBe('function');
+    });
+
+    it('does not export mTLS verifier internals (verifyMtls is not part of the public surface)', () => {
       const {
-        assertValidMtlsOptions,
         verifyMtls,
         calculateCertificateThumbprint,
         assertCertificateConfirmation,
       } = require('../src');
 
-      expect(typeof assertValidMtlsOptions).toBe('function');
-      expect(typeof verifyMtls).toBe('function');
-      expect(typeof calculateCertificateThumbprint).toBe('function');
-      expect(typeof assertCertificateConfirmation).toBe('function');
+      expect(verifyMtls).toBeUndefined();
+      expect(calculateCertificateThumbprint).toBeUndefined();
+      expect(assertCertificateConfirmation).toBeUndefined();
     });
   });
 });

--- a/packages/access-token-jwt/test/mtls-verifier.test.ts
+++ b/packages/access-token-jwt/test/mtls-verifier.test.ts
@@ -1,0 +1,197 @@
+import {
+  calculateCertificateThumbprint,
+  assertCertificateConfirmation,
+  verifyMtls,
+  type MtlsJWTPayload,
+} from '../src/mtls-verifier';
+
+import { InvalidRequestError, InvalidTokenError } from 'oauth2-bearer';
+
+import { createHash } from 'crypto';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { writeFileSync, rmSync, readFileSync, mkdirSync } from 'fs';
+
+// A real self-signed certificate generated once for the suite, plus a second,
+// unrelated certificate to exercise thumbprint mismatches.
+let certPem: string;
+let certDer: Buffer;
+let thumbprint: string;
+let otherCertPem: string;
+let otherThumbprint: string;
+
+function generateCert(dir: string, cn: string): { pem: string } {
+  const key = join(dir, `${cn}.key`);
+  const crt = join(dir, `${cn}.crt`);
+  execFileSync('openssl', [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-keyout',
+    key,
+    '-out',
+    crt,
+    '-days',
+    '1',
+    '-nodes',
+    '-subj',
+    `/CN=${cn}`,
+  ]);
+  return { pem: readFileSync(crt, 'utf8') };
+}
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+beforeAll(() => {
+  const dir = join(tmpdir(), `mtls-test-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  try {
+    certPem = generateCert(dir, 'client').pem;
+    otherCertPem = generateCert(dir, 'other').pem;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  const PEM_RE =
+    /-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\s]+?)-----END CERTIFICATE-----/;
+  certDer = Buffer.from(certPem.match(PEM_RE)![1].replace(/\s+/g, ''), 'base64');
+  thumbprint = base64url(createHash('sha256').update(certDer).digest());
+
+  const otherDer = Buffer.from(
+    otherCertPem.match(PEM_RE)![1].replace(/\s+/g, ''),
+    'base64'
+  );
+  otherThumbprint = base64url(createHash('sha256').update(otherDer).digest());
+});
+
+describe('calculateCertificateThumbprint', () => {
+  it('computes base64url(SHA-256(DER)) from a PEM string', () => {
+    expect(calculateCertificateThumbprint(certPem)).toBe(thumbprint);
+  });
+
+  it('computes the same thumbprint from DER bytes', () => {
+    expect(calculateCertificateThumbprint(certDer)).toBe(thumbprint);
+  });
+
+  it('accepts a Uint8Array of DER bytes', () => {
+    expect(calculateCertificateThumbprint(new Uint8Array(certDer))).toBe(
+      thumbprint
+    );
+  });
+
+  it('throws InvalidRequestError for a non-PEM string', () => {
+    expect(() => calculateCertificateThumbprint('not a cert')).toThrow(
+      InvalidRequestError
+    );
+  });
+
+  it('throws InvalidRequestError for empty DER bytes', () => {
+    expect(() => calculateCertificateThumbprint(Buffer.alloc(0))).toThrow(
+      InvalidRequestError
+    );
+  });
+});
+
+describe('assertCertificateConfirmation', () => {
+  it('returns the x5t#S256 thumbprint from a valid cnf claim', () => {
+    const claims: MtlsJWTPayload = { cnf: { 'x5t#S256': thumbprint } };
+    expect(assertCertificateConfirmation(claims)).toBe(thumbprint);
+  });
+
+  it('throws InvalidTokenError when cnf is missing', () => {
+    expect(() => assertCertificateConfirmation({})).toThrow(InvalidTokenError);
+  });
+
+  it('throws InvalidTokenError when cnf is not an object', () => {
+    expect(() =>
+      assertCertificateConfirmation({ cnf: 'nope' } as unknown as MtlsJWTPayload)
+    ).toThrow('Invalid "cnf" confirmation claim structure');
+  });
+
+  it('throws InvalidTokenError when cnf has more than one confirmation method', () => {
+    const claims = {
+      cnf: { 'x5t#S256': thumbprint, jkt: 'abc' },
+    } as unknown as MtlsJWTPayload;
+    expect(() => assertCertificateConfirmation(claims)).toThrow(
+      'Multiple confirmation claims are not supported'
+    );
+  });
+
+  it('throws InvalidTokenError when x5t#S256 is absent', () => {
+    const claims = { cnf: { jkt: 'abc' } } as unknown as MtlsJWTPayload;
+    expect(() => assertCertificateConfirmation(claims)).toThrow(
+      'no x5t#S256 confirmation claim'
+    );
+  });
+
+  it('throws InvalidTokenError when x5t#S256 is not a string', () => {
+    const claims = {
+      cnf: { 'x5t#S256': 123 },
+    } as unknown as MtlsJWTPayload;
+    expect(() => assertCertificateConfirmation(claims)).toThrow(
+      'Malformed "x5t#S256" confirmation claim'
+    );
+  });
+
+  it('throws InvalidTokenError when x5t#S256 is an empty string', () => {
+    const claims: MtlsJWTPayload = { cnf: { 'x5t#S256': '' } };
+    expect(() => assertCertificateConfirmation(claims)).toThrow(
+      'Invalid "x5t#S256" confirmation claim'
+    );
+  });
+});
+
+describe('verifyMtls', () => {
+  it('resolves when the presented certificate matches the binding', async () => {
+    await expect(
+      verifyMtls({
+        accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
+        clientCertificate: certPem,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts a DER Buffer as the presented certificate', async () => {
+    await expect(
+      verifyMtls({
+        accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
+        clientCertificate: certDer,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws InvalidRequestError when no certificate is presented', async () => {
+    await expect(
+      verifyMtls({
+        accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
+        clientCertificate: undefined,
+      })
+    ).rejects.toThrow(InvalidRequestError);
+  });
+
+  it('throws InvalidTokenError when the thumbprint does not match', async () => {
+    await expect(
+      verifyMtls({
+        accessTokenClaims: { cnf: { 'x5t#S256': otherThumbprint } },
+        clientCertificate: certPem,
+      })
+    ).rejects.toThrow('JWT Access Token confirmation mismatch');
+  });
+
+  it('throws InvalidTokenError when the token has no cnf claim', async () => {
+    await expect(
+      verifyMtls({
+        accessTokenClaims: {},
+        clientCertificate: certPem,
+      })
+    ).rejects.toThrow(InvalidTokenError);
+  });
+});

--- a/packages/access-token-jwt/test/mtls-verifier.test.ts
+++ b/packages/access-token-jwt/test/mtls-verifier.test.ts
@@ -150,48 +150,48 @@ describe('assertCertificateConfirmation', () => {
 });
 
 describe('verifyMtls', () => {
-  it('resolves when the presented certificate matches the binding', async () => {
-    await expect(
+  it('returns undefined when the presented certificate matches the binding', () => {
+    expect(
       verifyMtls({
         accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
         clientCertificate: certPem,
       })
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
   });
 
-  it('accepts a DER Buffer as the presented certificate', async () => {
-    await expect(
+  it('accepts a DER Buffer as the presented certificate', () => {
+    expect(
       verifyMtls({
         accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
         clientCertificate: certDer,
       })
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
   });
 
-  it('throws InvalidRequestError when no certificate is presented', async () => {
-    await expect(
+  it('throws InvalidRequestError when no certificate is presented', () => {
+    expect(() =>
       verifyMtls({
         accessTokenClaims: { cnf: { 'x5t#S256': thumbprint } },
         clientCertificate: undefined,
       })
-    ).rejects.toThrow(InvalidRequestError);
+    ).toThrow(InvalidRequestError);
   });
 
-  it('throws InvalidTokenError when the thumbprint does not match', async () => {
-    await expect(
+  it('throws InvalidTokenError when the thumbprint does not match', () => {
+    expect(() =>
       verifyMtls({
         accessTokenClaims: { cnf: { 'x5t#S256': otherThumbprint } },
         clientCertificate: certPem,
       })
-    ).rejects.toThrow('JWT Access Token confirmation mismatch');
+    ).toThrow('JWT Access Token confirmation mismatch');
   });
 
-  it('throws InvalidTokenError when the token has no cnf claim', async () => {
-    await expect(
+  it('throws InvalidTokenError when the token has no cnf claim', () => {
+    expect(() =>
       verifyMtls({
         accessTokenClaims: {},
         clientCertificate: certPem,
       })
-    ).rejects.toThrow(InvalidTokenError);
+    ).toThrow(InvalidTokenError);
   });
 });

--- a/packages/access-token-jwt/test/mtls-verifier.test.ts
+++ b/packages/access-token-jwt/test/mtls-verifier.test.ts
@@ -11,7 +11,7 @@ import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { writeFileSync, rmSync, readFileSync, mkdirSync } from 'fs';
+import { rmSync, readFileSync, mkdirSync } from 'fs';
 
 // A real self-signed certificate generated once for the suite, plus a second,
 // unrelated certificate to exercise thumbprint mismatches.

--- a/packages/access-token-jwt/test/token-verifier.test.ts
+++ b/packages/access-token-jwt/test/token-verifier.test.ts
@@ -2484,5 +2484,31 @@ describe('tokenVerifier / mTLS', () => {
         true
       );
     });
+
+    it('does not apply mtls.required to a DPoP-bound token when DPoP is also enabled', async () => {
+      // DPoP is evaluated first and takes precedence: a DPoP-bound token is
+      // handled by the DPoP path and satisfies the request, so mtls.required
+      // does not reject it. mtls.required is scoped to the mTLS path.
+      (dpopVerifier.verifyDPoP as sinon.SinonSpy).restore?.();
+      sinon.stub(dpopVerifier, 'verifyDPoP').resolves();
+
+      const jwtResult = createJwtResult({ sub: 'user', cnf: { jkt: 'abc' } });
+      const { verifier } = createVerifier(
+        jwtResult,
+        { mtls: { required: true } },
+        {
+          headers: { authorization: 'DPoP ' + dummyJwt, dpop: 'proof.jwt' },
+          clientCertificate: CERT,
+        }
+      );
+
+      await expect(verifier.verify()).resolves.toEqual(jwtResult);
+      expect((dpopVerifier.verifyDPoP as sinon.SinonStub).calledOnce).toBe(
+        true
+      );
+      expect((mtlsVerifier.verifyMtls as sinon.SinonStub).notCalled).toBe(
+        true
+      );
+    });
   });
 });

--- a/packages/access-token-jwt/test/token-verifier.test.ts
+++ b/packages/access-token-jwt/test/token-verifier.test.ts
@@ -2296,7 +2296,15 @@ describe('assertValidMtlsOptions', () => {
   it('throws when required is true but enabled is false', () => {
     expect(() =>
       assertValidMtlsOptions({ enabled: false, required: true })
-    ).toThrow('cannot set "required" to true when "enabled" is false');
+    ).toThrow(
+      '"required" can only be set to true when "enabled" is also true'
+    );
+  });
+
+  it('throws when required is true but enabled is not set (mTLS is opt-in)', () => {
+    expect(() => assertValidMtlsOptions({ required: true })).toThrow(
+      '"required" can only be set to true when "enabled" is also true'
+    );
   });
 });
 
@@ -2326,15 +2334,24 @@ describe('tokenVerifier / mTLS', () => {
     // Stub the actual certificate validation; these tests assert orchestration
     // (whether verifyMtls is invoked and with what), not the crypto itself.
     if (!(mtlsVerifier.verifyMtls as any).restore) {
-      sinon.stub(mtlsVerifier, 'verifyMtls').resolves();
+      sinon.stub(mtlsVerifier, 'verifyMtls').returns(undefined);
     }
   });
 
   afterEach(() => sinon.restore());
 
   describe('shouldVerifyMtls', () => {
-    it('returns true for a cert-bound token (cnf.x5t#S256) by default', () => {
+    it('returns false for a cert-bound token (cnf.x5t#S256) by default (mTLS is opt-in)', () => {
       const { verifier } = createVerifier(createJwtResult({ sub: 'user' }));
+      expect(
+        verifier.shouldVerifyMtls({ cnf: { 'x5t#S256': 'abc' } } as any)
+      ).toBe(false);
+    });
+
+    it('returns true for a cert-bound token when explicitly enabled', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }), {
+        mtls: { enabled: true },
+      });
       expect(
         verifier.shouldVerifyMtls({ cnf: { 'x5t#S256': 'abc' } } as any)
       ).toBe(true);
@@ -2346,15 +2363,17 @@ describe('tokenVerifier / mTLS', () => {
     });
 
     it('returns false for a DPoP-bound token (cnf.jkt)', () => {
-      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }));
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }), {
+        mtls: { enabled: true },
+      });
       expect(verifier.shouldVerifyMtls({ cnf: { jkt: 'abc' } } as any)).toBe(
         false
       );
     });
 
-    it('returns true for any token when required', () => {
+    it('returns true for any token when enabled and required', () => {
       const { verifier } = createVerifier(createJwtResult({ sub: 'user' }), {
-        mtls: { required: true },
+        mtls: { enabled: true, required: true },
       });
       expect(verifier.shouldVerifyMtls({ sub: 'user' } as any)).toBe(true);
     });
@@ -2377,7 +2396,7 @@ describe('tokenVerifier / mTLS', () => {
       });
       const { verifier } = createVerifier(
         jwtResult,
-        {},
+        { mtls: { enabled: true } },
         {
           headers: { authorization: 'Bearer ' + dummyJwt },
           clientCertificate: CERT,
@@ -2425,11 +2444,11 @@ describe('tokenVerifier / mTLS', () => {
       expect((mtlsVerifier.verifyMtls as sinon.SinonStub).notCalled).toBe(true);
     });
 
-    it('calls verifyMtls for every token when required', async () => {
+    it('calls verifyMtls for every token when enabled and required', async () => {
       const jwtResult = createJwtResult({ sub: 'user' });
       const { verifier } = createVerifier(
         jwtResult,
-        { mtls: { required: true } },
+        { mtls: { enabled: true, required: true } },
         {
           headers: { authorization: 'Bearer ' + dummyJwt },
           clientCertificate: CERT,
@@ -2469,7 +2488,7 @@ describe('tokenVerifier / mTLS', () => {
       const jwtResult = createJwtResult({ sub: 'user', cnf: { jkt: 'abc' } });
       const { verifier } = createVerifier(
         jwtResult,
-        {},
+        { mtls: { enabled: true } },
         {
           headers: { authorization: 'DPoP ' + dummyJwt, dpop: 'proof.jwt' },
           clientCertificate: CERT,
@@ -2495,7 +2514,7 @@ describe('tokenVerifier / mTLS', () => {
       const jwtResult = createJwtResult({ sub: 'user', cnf: { jkt: 'abc' } });
       const { verifier } = createVerifier(
         jwtResult,
-        { mtls: { required: true } },
+        { mtls: { enabled: true, required: true } },
         {
           headers: { authorization: 'DPoP ' + dummyJwt, dpop: 'proof.jwt' },
           clientCertificate: CERT,

--- a/packages/access-token-jwt/test/token-verifier.test.ts
+++ b/packages/access-token-jwt/test/token-verifier.test.ts
@@ -20,6 +20,7 @@ import {
   ASYMMETRIC_ALGS as SUPPORTED_ALGS,
 } from '../src/jwt-verifier';
 import sinon from 'sinon';
+import { AssertionError } from 'assert';
 import * as dpopVerifier from '../src/dpop-verifier';
 import * as mtlsVerifier from '../src/mtls-verifier';
 import { assertValidMtlsOptions } from '../src/token-verifier';
@@ -2276,6 +2277,9 @@ describe('assertValidMtlsOptions', () => {
   });
 
   it('throws when mtls is not an object', () => {
+    expect(() => assertValidMtlsOptions('nope' as any)).toThrow(
+      AssertionError
+    );
     expect(() =>
       assertValidMtlsOptions('nope' as any)
     ).toThrow('"mtls" must be an object');
@@ -2284,10 +2288,16 @@ describe('assertValidMtlsOptions', () => {
   it('throws when enabled is not a boolean', () => {
     expect(() =>
       assertValidMtlsOptions({ enabled: 'yes' as any })
+    ).toThrow(AssertionError);
+    expect(() =>
+      assertValidMtlsOptions({ enabled: 'yes' as any })
     ).toThrow('"enabled" must be a boolean');
   });
 
   it('throws when required is not a boolean', () => {
+    expect(() =>
+      assertValidMtlsOptions({ required: 1 as any })
+    ).toThrow(AssertionError);
     expect(() =>
       assertValidMtlsOptions({ required: 1 as any })
     ).toThrow('"required" must be a boolean');
@@ -2296,12 +2306,18 @@ describe('assertValidMtlsOptions', () => {
   it('throws when required is true but enabled is false', () => {
     expect(() =>
       assertValidMtlsOptions({ enabled: false, required: true })
+    ).toThrow(AssertionError);
+    expect(() =>
+      assertValidMtlsOptions({ enabled: false, required: true })
     ).toThrow(
       '"required" can only be set to true when "enabled" is also true'
     );
   });
 
   it('throws when required is true but enabled is not set (mTLS is opt-in)', () => {
+    expect(() => assertValidMtlsOptions({ required: true })).toThrow(
+      AssertionError
+    );
     expect(() => assertValidMtlsOptions({ required: true })).toThrow(
       '"required" can only be set to true when "enabled" is also true'
     );

--- a/packages/access-token-jwt/test/token-verifier.test.ts
+++ b/packages/access-token-jwt/test/token-verifier.test.ts
@@ -21,6 +21,8 @@ import {
 } from '../src/jwt-verifier';
 import sinon from 'sinon';
 import * as dpopVerifier from '../src/dpop-verifier';
+import * as mtlsVerifier from '../src/mtls-verifier';
+import { assertValidMtlsOptions } from '../src/token-verifier';
 
 const createJwtResult = (payload: any, token?: string): VerifyJwtResult => ({
   token: token || 'abc.def.ghi',
@@ -2258,6 +2260,229 @@ describe('tokenVerifier / verify', () => {
       expectedMessage: '',
       expectedCode: '',
       expectedChallengeIncludes: ['Bearer realm="api"'],
+    });
+  });
+});
+
+describe('assertValidMtlsOptions', () => {
+  it('accepts undefined', () => {
+    expect(() => assertValidMtlsOptions(undefined)).not.toThrow();
+  });
+
+  it('accepts a valid options object', () => {
+    expect(() =>
+      assertValidMtlsOptions({ enabled: true, required: false })
+    ).not.toThrow();
+  });
+
+  it('throws when mtls is not an object', () => {
+    expect(() =>
+      assertValidMtlsOptions('nope' as any)
+    ).toThrow('"mtls" must be an object');
+  });
+
+  it('throws when enabled is not a boolean', () => {
+    expect(() =>
+      assertValidMtlsOptions({ enabled: 'yes' as any })
+    ).toThrow('"enabled" must be a boolean');
+  });
+
+  it('throws when required is not a boolean', () => {
+    expect(() =>
+      assertValidMtlsOptions({ required: 1 as any })
+    ).toThrow('"required" must be a boolean');
+  });
+
+  it('throws when required is true but enabled is false', () => {
+    expect(() =>
+      assertValidMtlsOptions({ enabled: false, required: true })
+    ).toThrow('cannot set "required" to true when "enabled" is false');
+  });
+});
+
+describe('tokenVerifier / mTLS', () => {
+  const dummyJwt = 'abc.def.ghi';
+  const CERT = 'dummy-pem';
+  const baseRequest = {
+    url: 'https://api.example.com/resource',
+    method: 'GET',
+    headers: {},
+  };
+
+  const createVerifier = (
+    jwtResult: VerifyJwtResult,
+    options: AuthOptions = {},
+    requestOverrides: Record<string, unknown> = {}
+  ) => {
+    const verifyJwtStub = sinon.stub().resolves(jwtResult);
+    const verifier = tokenVerifier(verifyJwtStub, options, {
+      ...baseRequest,
+      ...requestOverrides,
+    });
+    return { verifier, verifyJwtStub };
+  };
+
+  beforeEach(() => {
+    // Stub the actual certificate validation; these tests assert orchestration
+    // (whether verifyMtls is invoked and with what), not the crypto itself.
+    if (!(mtlsVerifier.verifyMtls as any).restore) {
+      sinon.stub(mtlsVerifier, 'verifyMtls').resolves();
+    }
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('shouldVerifyMtls', () => {
+    it('returns true for a cert-bound token (cnf.x5t#S256) by default', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }));
+      expect(
+        verifier.shouldVerifyMtls({ cnf: { 'x5t#S256': 'abc' } } as any)
+      ).toBe(true);
+    });
+
+    it('returns false for a plain bearer token by default', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }));
+      expect(verifier.shouldVerifyMtls({ sub: 'user' } as any)).toBe(false);
+    });
+
+    it('returns false for a DPoP-bound token (cnf.jkt)', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }));
+      expect(verifier.shouldVerifyMtls({ cnf: { jkt: 'abc' } } as any)).toBe(
+        false
+      );
+    });
+
+    it('returns true for any token when required', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }), {
+        mtls: { required: true },
+      });
+      expect(verifier.shouldVerifyMtls({ sub: 'user' } as any)).toBe(true);
+    });
+
+    it('returns false when disabled, even for a cert-bound token', () => {
+      const { verifier } = createVerifier(createJwtResult({ sub: 'user' }), {
+        mtls: { enabled: false },
+      });
+      expect(
+        verifier.shouldVerifyMtls({ cnf: { 'x5t#S256': 'abc' } } as any)
+      ).toBe(false);
+    });
+  });
+
+  describe('verify', () => {
+    it('calls verifyMtls with the resolved certificate for a cert-bound token', async () => {
+      const jwtResult = createJwtResult({
+        sub: 'user',
+        cnf: { 'x5t#S256': 'abc' },
+      });
+      const { verifier } = createVerifier(
+        jwtResult,
+        {},
+        {
+          headers: { authorization: 'Bearer ' + dummyJwt },
+          clientCertificate: CERT,
+        }
+      );
+
+      const result = await verifier.verify();
+      expect(result).toEqual(jwtResult);
+
+      const stub = mtlsVerifier.verifyMtls as sinon.SinonStub;
+      expect(stub.calledOnce).toBe(true);
+      expect(stub.firstCall.args[0].clientCertificate).toBe(CERT);
+      expect(stub.firstCall.args[0].accessTokenClaims).toEqual(
+        jwtResult.payload
+      );
+    });
+
+    it('does not treat a Bearer cert-bound token as a DPoP scheme violation', async () => {
+      const jwtResult = createJwtResult({
+        sub: 'user',
+        cnf: { 'x5t#S256': 'abc' },
+      });
+      const { verifier } = createVerifier(
+        jwtResult,
+        {},
+        {
+          headers: { authorization: 'Bearer ' + dummyJwt },
+          clientCertificate: CERT,
+        }
+      );
+
+      // Should resolve, not throw the "DPoP-bound token requires DPoP scheme" error.
+      await expect(verifier.verify()).resolves.toEqual(jwtResult);
+    });
+
+    it('skips verifyMtls for a plain bearer token', async () => {
+      const jwtResult = createJwtResult({ sub: 'user' });
+      const { verifier } = createVerifier(
+        jwtResult,
+        {},
+        { headers: { authorization: 'Bearer ' + dummyJwt } }
+      );
+
+      await verifier.verify();
+      expect((mtlsVerifier.verifyMtls as sinon.SinonStub).notCalled).toBe(true);
+    });
+
+    it('calls verifyMtls for every token when required', async () => {
+      const jwtResult = createJwtResult({ sub: 'user' });
+      const { verifier } = createVerifier(
+        jwtResult,
+        { mtls: { required: true } },
+        {
+          headers: { authorization: 'Bearer ' + dummyJwt },
+          clientCertificate: CERT,
+        }
+      );
+
+      await verifier.verify();
+      expect((mtlsVerifier.verifyMtls as sinon.SinonStub).calledOnce).toBe(
+        true
+      );
+    });
+
+    it('does not call verifyMtls when mTLS is disabled', async () => {
+      const jwtResult = createJwtResult({
+        sub: 'user',
+        cnf: { 'x5t#S256': 'abc' },
+      });
+      const { verifier } = createVerifier(
+        jwtResult,
+        { mtls: { enabled: false } },
+        {
+          headers: { authorization: 'Bearer ' + dummyJwt },
+          clientCertificate: CERT,
+        }
+      );
+
+      await verifier.verify();
+      expect((mtlsVerifier.verifyMtls as sinon.SinonStub).notCalled).toBe(
+        true
+      );
+    });
+
+    it('prefers DPoP over mTLS: a cnf.jkt token routes to verifyDPoP, not verifyMtls', async () => {
+      (dpopVerifier.verifyDPoP as sinon.SinonSpy).restore?.();
+      sinon.stub(dpopVerifier, 'verifyDPoP').resolves();
+
+      const jwtResult = createJwtResult({ sub: 'user', cnf: { jkt: 'abc' } });
+      const { verifier } = createVerifier(
+        jwtResult,
+        {},
+        {
+          headers: { authorization: 'DPoP ' + dummyJwt, dpop: 'proof.jwt' },
+          clientCertificate: CERT,
+        }
+      );
+
+      await verifier.verify();
+      expect((dpopVerifier.verifyDPoP as sinon.SinonStub).calledOnce).toBe(
+        true
+      );
+      expect((mtlsVerifier.verifyMtls as sinon.SinonStub).notCalled).toBe(
+        true
+      );
     });
   });
 });

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -14,6 +14,7 @@
   - [Require every token to be certificate-bound](#require-every-token-to-be-certificate-bound)
   - [Disable mTLS validation](#disable-mtls-validation)
   - [mTLS Behavior Matrix](#mtls-behavior-matrix)
+  - [Using mTLS and DPoP together](#using-mtls-and-dpop-together)
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
   - [Static list of issuers](#static-list-of-issuers)
   - [Dynamic resolver](#dynamic-resolver)
@@ -450,7 +451,18 @@ app.use(
 | `false`   | `false`    | `cnf.x5t#S256` claims are not validated. Tokens are accepted as plain Bearer JWTs.                                             |
 | `false`   | `true`     | Invalid configuration. `mtls` is disabled, so a binding cannot be required (throws on startup).                               |
 
-## Multiple Custom Domains (MCD)
+### Using mTLS and DPoP together
+
+An Auth0 Resource Server is configured with a single sender-constraining method, so in practice a token carries at most one confirmation claim (`cnf.jkt` for DPoP or `cnf.x5t#S256` for mTLS, never both). Both mechanisms are enabled by default, and each fires only for the tokens it applies to, so leaving both on is safe. If you do run both, it helps to know how the SDK routes a request when both are enabled.
+
+**DPoP is evaluated first and takes precedence.** For a given request the SDK runs at most one of the two verifiers. DPoP is checked first; mTLS validation runs only when the DPoP path does not apply. The DPoP path applies when the request uses the `DPoP` scheme, carries a `DPoP` proof header, has a `cnf.jkt` token, or DPoP is required. Otherwise the mTLS path applies to a `cnf.x5t#S256` token (or to every token when `mtls.required` is `true`).
+
+Two consequences are worth calling out:
+
+- **`mtls: { required: true }` is scoped to the mTLS path, not a global "every token must be certificate-bound" gate.** With DPoP also enabled, a valid DPoP-bound token is handled by the DPoP path and satisfies the request; the mTLS requirement is not applied to it. `mtls.required` rejects tokens that reach the mTLS path without a certificate binding, it does not override DPoP.
+- **`dpop: { required: true }` makes the `mtls` options inert.** When DPoP is required, every request is routed to the DPoP path, so the mTLS verifier never runs regardless of the `mtls` configuration. Setting both `dpop.required` and `mtls.required` to `true` is contradictory (a token cannot be bound by both methods at once); the SDK does not reject that combination at startup, but DPoP wins and no token will ever be accepted by the mTLS path. Enable exactly one `required` method to match how your Resource Server is configured.
+
+
 
 Use `mcd` to accept JWT tokens from multiple custom domains belonging to the **same Authorization Server**. `mcd` and `issuerBaseURL` are mutually exclusive — use one or the other.
 

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -7,6 +7,13 @@
   - [Customize DPoP validation behavior](#customize-dpop-validation-behavior)
   - [Hostname Resolution (`req.host` and `req.protocol`)](#hostname-resolution-reqhost-and-reqprotocol)
   - [DPoP jti Replay Prevention](#dpop-jti-replay-prevention)
+- [mTLS Certificate-Bound Tokens](#mtls-certificate-bound-tokens)
+  - [Resolve the client certificate with `getCertificate`](#resolve-the-client-certificate-with-getcertificate)
+  - [Terminating TLS with a proxy](#terminating-tls-with-a-proxy)
+  - [Accept both cert-bound and regular Bearer tokens (default)](#accept-both-cert-bound-and-regular-bearer-tokens-default)
+  - [Require every token to be certificate-bound](#require-every-token-to-be-certificate-bound)
+  - [Disable mTLS validation](#disable-mtls-validation)
+  - [mTLS Behavior Matrix](#mtls-behavior-matrix)
 - [Multiple Custom Domains (MCD)](#multiple-custom-domains-mcd)
   - [Static list of issuers](#static-list-of-issuers)
   - [Dynamic resolver](#dynamic-resolver)
@@ -293,6 +300,155 @@ app.get('/api/protected', (req, res) => {
   res.json({ message: 'Access granted' });
 });
 ```
+
+## mTLS Certificate-Bound Tokens
+
+[mTLS](https://www.rfc-editor.org/rfc/rfc8705) (Mutual TLS, RFC 8705) sender-constrains an access token to the client certificate that was used to obtain it. The authorization server embeds a `cnf.x5t#S256` claim (the base64url-encoded SHA-256 thumbprint of the client certificate) into the token. This middleware validates that claim: it recomputes the thumbprint of the certificate presented on the current TLS connection and rejects the request if it does not match.
+
+Because APIs almost always run behind a TLS-terminating proxy (nginx, ALB, Cloudflare, etc.) that forwards the client certificate in a request header, the SDK cannot know where your certificate lives. You supply a `getCertificate` function that pulls it out of the request, and the SDK does the rest.
+
+> mTLS and DPoP are mutually exclusive per token: a token carries at most one confirmation method. If a token is DPoP-bound (`cnf.jkt`), the DPoP path handles it and mTLS validation is skipped.
+
+### Resolve the client certificate with `getCertificate`
+
+`getCertificate(req)` returns the client certificate for the current request, or `undefined` when none is present. It may return either the PEM text (what most proxies forward, usually URL-encoded) or the raw DER bytes.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuerBaseURL: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    getCertificate: (req) => {
+      // nginx forwarding URL-encoded PEM in a header (see "Terminating TLS with a proxy" below):
+      const pem = req.headers['client-certificate'];
+      return typeof pem === 'string' ? decodeURIComponent(pem) : undefined;
+    },
+  })
+);
+```
+
+If your Node process terminates TLS directly instead of sitting behind a proxy, return the peer certificate's DER bytes:
+
+```js
+getCertificate: (req) => req.socket.getPeerCertificate()?.raw || undefined;
+```
+
+### Terminating TLS with a proxy
+
+Most deployments terminate TLS at a reverse proxy and forward the client certificate to the API in a request header. The header name and encoding are up to you; `getCertificate` just has to read it back out. For example, with nginx requesting the client certificate and forwarding it as URL-encoded PEM:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.example.com;
+
+    ssl_certificate     /path/to/server.crt;
+    ssl_certificate_key /path/to/server.key;
+
+    # Request the client certificate. Use `optional_no_ca` when the certificate
+    # is validated downstream (e.g. by Auth0 at token issuance) rather than by
+    # nginx; use `on` with `ssl_client_certificate` to have nginx verify a CA.
+    ssl_verify_client optional_no_ca;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        # $ssl_client_escaped_cert is the URL-encoded PEM of the presented cert.
+        proxy_set_header client-certificate $ssl_client_escaped_cert;
+    }
+}
+```
+
+The matching `getCertificate` reads that header and URL-decodes it, as shown in the example above.
+
+> Only trust a forwarded client-certificate header on connections that reach your app **through** the proxy. If the app is also reachable directly, a client could set the header itself and forge a binding. Bind the app to a private interface (or otherwise restrict it to the proxy), and have the proxy overwrite the header on every request so an inbound value cannot pass through.
+
+### Accept both cert-bound and regular Bearer tokens (default)
+
+By default mTLS is enabled but not required. A certificate-bound token is validated against the presented certificate; a token with no `cnf.x5t#S256` claim passes through as a regular Bearer token.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuerBaseURL: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    getCertificate: (req) => {
+      const pem = req.headers['client-certificate'];
+      return typeof pem === 'string' ? decodeURIComponent(pem) : undefined;
+    },
+    mtls: {
+      enabled: true, // Validate cnf.x5t#S256 when present (default)
+      required: false, // Non-bound tokens are still accepted (default)
+    },
+  })
+);
+
+app.get('/api/resource', (req, res) => {
+  res.send('Access granted');
+});
+```
+
+### Require every token to be certificate-bound
+
+To reject any token that is not sender-constrained to a client certificate, set `required: true`. This matches an Auth0 Resource Server configured with **Token Sender-Constraining → mTLS → Always**.
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuerBaseURL: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    getCertificate: (req) => {
+      const pem = req.headers['client-certificate'];
+      return typeof pem === 'string' ? decodeURIComponent(pem) : undefined;
+    },
+    mtls: {
+      enabled: true,
+      required: true, // Reject tokens with no cnf.x5t#S256 binding
+    },
+  })
+);
+
+app.get('/api/secure-resource', (req, res) => {
+  res.send('Certificate-bound token validated');
+});
+```
+
+With `required: true` the SDK returns:
+
+- `400 invalid_request` when a cert-bound token arrives but no certificate was presented on the connection.
+- `401 invalid_token` when the presented certificate's thumbprint does not match the token's `cnf.x5t#S256`, or when the token carries no binding at all.
+
+### Disable mTLS validation
+
+To ignore `cnf.x5t#S256` claims entirely (for example while a certificate-bound token is still validated as a plain JWT):
+
+```js
+const { auth } = require('express-oauth2-jwt-bearer');
+
+app.use(
+  auth({
+    issuerBaseURL: 'https://YOUR_ISSUER_DOMAIN',
+    audience: 'https://my-api.com',
+    mtls: {
+      enabled: false, // cnf.x5t#S256 claims are not validated
+    },
+  })
+);
+```
+
+### mTLS Behavior Matrix
+
+| `enabled` | `required` | Behavior                                                                                                                      |
+| --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `true`    | `false`    | **Default behavior**. Cert-bound tokens are validated against the presented certificate; tokens with no `cnf.x5t#S256` pass through. |
+| `true`    | `true`     | Every token must be certificate-bound. A missing certificate → `400 invalid_request`; a thumbprint mismatch or unbound token → `401 invalid_token`. |
+| `false`   | `false`    | `cnf.x5t#S256` claims are not validated. Tokens are accepted as plain Bearer JWTs.                                             |
+| `false`   | `true`     | Invalid configuration. `mtls` is disabled, so a binding cannot be required (throws on startup).                               |
 
 ## Multiple Custom Domains (MCD)
 

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -10,7 +10,7 @@
 - [mTLS Certificate-Bound Tokens](#mtls-certificate-bound-tokens)
   - [Resolve the client certificate with `getCertificate`](#resolve-the-client-certificate-with-getcertificate)
   - [Terminating TLS with a proxy](#terminating-tls-with-a-proxy)
-  - [Accept both cert-bound and regular Bearer tokens (default)](#accept-both-cert-bound-and-regular-bearer-tokens-default)
+  - [Accept both cert-bound and regular Bearer tokens (default once `getCertificate` is set)](#accept-both-cert-bound-and-regular-bearer-tokens-default-once-getcertificate-is-set)
   - [Require every token to be certificate-bound](#require-every-token-to-be-certificate-bound)
   - [Disable mTLS validation](#disable-mtls-validation)
   - [mTLS Behavior Matrix](#mtls-behavior-matrix)
@@ -308,6 +308,8 @@ app.get('/api/protected', (req, res) => {
 
 Because APIs almost always run behind a TLS-terminating proxy (nginx, ALB, Cloudflare, etc.) that forwards the client certificate in a request header, the SDK cannot know where your certificate lives. You supply a `getCertificate` function that pulls it out of the request, and the SDK does the rest.
 
+> mTLS is opt-in: unlike DPoP, it depends on a certificate resolver only you can supply, so it cannot safely default to on. Supplying `getCertificate` enables it automatically (`mtls.enabled` defaults to `true` once `getCertificate` is set); without `getCertificate`, `cnf.x5t#S256` claims are ignored entirely. Set `mtls: { enabled: false }` explicitly to keep mTLS off while still resolving certificates for your own use.
+
 > mTLS and DPoP are mutually exclusive per token: a token carries at most one confirmation method. If a token is DPoP-bound (`cnf.jkt`), the DPoP path handles it and mTLS validation is skipped.
 
 ### Resolve the client certificate with `getCertificate`
@@ -365,9 +367,9 @@ The matching `getCertificate` reads that header and URL-decodes it, as shown in 
 
 > Only trust a forwarded client-certificate header on connections that reach your app **through** the proxy. If the app is also reachable directly, a client could set the header itself and forge a binding. Bind the app to a private interface (or otherwise restrict it to the proxy), and have the proxy overwrite the header on every request so an inbound value cannot pass through.
 
-### Accept both cert-bound and regular Bearer tokens (default)
+### Accept both cert-bound and regular Bearer tokens (default once `getCertificate` is set)
 
-By default mTLS is enabled but not required. A certificate-bound token is validated against the presented certificate; a token with no `cnf.x5t#S256` claim passes through as a regular Bearer token.
+Once `getCertificate` is supplied, mTLS is enabled but not required by default. A certificate-bound token is validated against the presented certificate; a token with no `cnf.x5t#S256` claim passes through as a regular Bearer token.
 
 ```js
 const { auth } = require('express-oauth2-jwt-bearer');
@@ -444,16 +446,17 @@ app.use(
 
 ### mTLS Behavior Matrix
 
-| `enabled` | `required` | Behavior                                                                                                                      |
-| --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `true`    | `false`    | **Default behavior**. Cert-bound tokens are validated against the presented certificate; tokens with no `cnf.x5t#S256` pass through. |
-| `true`    | `true`     | Every token must be certificate-bound. A missing certificate → `400 invalid_request`; a thumbprint mismatch or unbound token → `401 invalid_token`. |
-| `false`   | `false`    | `cnf.x5t#S256` claims are not validated. Tokens are accepted as plain Bearer JWTs.                                             |
-| `false`   | `true`     | Invalid configuration. `mtls` is disabled, so a binding cannot be required (throws on startup).                               |
+| `getCertificate` | `enabled`         | `required` | Behavior                                                                                                                      |
+| ----------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| not set            | not set            | `false`    | **Default**. mTLS is off; `cnf.x5t#S256` claims are ignored and tokens are accepted as plain Bearer JWTs.                     |
+| set                | not set (→ `true`) | `false`    | **Default once `getCertificate` is set**. Cert-bound tokens are validated against the presented certificate; tokens with no `cnf.x5t#S256` pass through. |
+| any                | `true`             | `true`     | Every token must be certificate-bound. A missing certificate → `400 invalid_request`; a thumbprint mismatch or unbound token → `401 invalid_token`. |
+| any                | `false`            | `false`    | `cnf.x5t#S256` claims are not validated. Tokens are accepted as plain Bearer JWTs.                                            |
+| any                | not `true`         | `true`     | Invalid configuration. `required` can only be `true` when `enabled` is also explicitly `true` (throws on startup).           |
 
 ### Using mTLS and DPoP together
 
-An Auth0 Resource Server is configured with a single sender-constraining method, so in practice a token carries at most one confirmation claim (`cnf.jkt` for DPoP or `cnf.x5t#S256` for mTLS, never both). Both mechanisms are enabled by default, and each fires only for the tokens it applies to, so leaving both on is safe. If you do run both, it helps to know how the SDK routes a request when both are enabled.
+An Auth0 Resource Server is configured with a single sender-constraining method, so in practice a token carries at most one confirmation claim (`cnf.jkt` for DPoP or `cnf.x5t#S256` for mTLS, never both). DPoP is enabled by default; mTLS is opt-in (see above). Each fires only for the tokens it applies to, so running both is safe. If you do run both, it helps to know how the SDK routes a request when both are enabled.
 
 **DPoP is evaluated first and takes precedence.** For a given request the SDK runs at most one of the two verifiers. DPoP is checked first; mTLS validation runs only when the DPoP path does not apply. The DPoP path applies when the request uses the `DPoP` scheme, carries a `DPoP` proof header, has a `cnf.jkt` token, or DPoP is required. Otherwise the mTLS path applies to a `cnf.x5t#S256` token (or to every token when `mtls.required` is `true`).
 

--- a/packages/express-oauth2-jwt-bearer/EXAMPLES.md
+++ b/packages/express-oauth2-jwt-bearer/EXAMPLES.md
@@ -465,7 +465,7 @@ Two consequences are worth calling out:
 - **`mtls: { required: true }` is scoped to the mTLS path, not a global "every token must be certificate-bound" gate.** With DPoP also enabled, a valid DPoP-bound token is handled by the DPoP path and satisfies the request; the mTLS requirement is not applied to it. `mtls.required` rejects tokens that reach the mTLS path without a certificate binding, it does not override DPoP.
 - **`dpop: { required: true }` makes the `mtls` options inert.** When DPoP is required, every request is routed to the DPoP path, so the mTLS verifier never runs regardless of the `mtls` configuration. Setting both `dpop.required` and `mtls.required` to `true` is contradictory (a token cannot be bound by both methods at once); the SDK does not reject that combination at startup, but DPoP wins and no token will ever be accepted by the mTLS path. Enable exactly one `required` method to match how your Resource Server is configured.
 
-
+## Multiple Custom Domains (MCD)
 
 Use `mcd` to accept JWT tokens from multiple custom domains belonging to the **same Authorization Server**. `mcd` and `issuerBaseURL` are mutually exclusive — use one or the other.
 

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -139,6 +139,18 @@ Auth0 Anonymous Sessions issues standard JWT Bearer tokens to unauthenticated us
 
 **See [Anonymous Sessions examples in `EXAMPLES.md`](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/EXAMPLES.md#anonymous-sessions)**
 
+#### mTLS Certificate-Bound Tokens
+
+This SDK supports [mTLS (Mutual TLS, RFC 8705)](https://www.rfc-editor.org/rfc/rfc8705) certificate-bound access tokens. It validates the token's `cnf.x5t#S256` claim against the client certificate presented on the TLS connection, which you resolve with a `getCertificate` function.
+
+To learn how to:
+- Resolve the client certificate from behind a TLS-terminating proxy with `getCertificate`
+- Accept both cert-bound and regular Bearer tokens (default)
+- Require every token to be certificate-bound
+- Disable mTLS validation
+
+**See [mTLS examples in `EXAMPLES.md`](https://github.com/auth0/node-oauth2-jwt-bearer/blob/main/packages/express-oauth2-jwt-bearer/EXAMPLES.md#mtls-certificate-bound-tokens)**
+
 
 ### Security Headers
 

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -141,11 +141,11 @@ Auth0 Anonymous Sessions issues standard JWT Bearer tokens to unauthenticated us
 
 #### mTLS Certificate-Bound Tokens
 
-This SDK supports [mTLS (Mutual TLS, RFC 8705)](https://www.rfc-editor.org/rfc/rfc8705) certificate-bound access tokens. It validates the token's `cnf.x5t#S256` claim against the client certificate presented on the TLS connection, which you resolve with a `getCertificate` function.
+This SDK supports [mTLS (Mutual TLS, RFC 8705)](https://www.rfc-editor.org/rfc/rfc8705) certificate-bound access tokens. It validates the token's `cnf.x5t#S256` claim against the client certificate presented on the TLS connection, which you resolve with a `getCertificate` function. mTLS is opt-in: supplying `getCertificate` enables it, unless you set `mtls.enabled` explicitly.
 
 To learn how to:
 - Resolve the client certificate from behind a TLS-terminating proxy with `getCertificate`
-- Accept both cert-bound and regular Bearer tokens (default)
+- Accept both cert-bound and regular Bearer tokens (default once `getCertificate` is set)
 - Require every token to be certificate-bound
 - Disable mTLS validation
 

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -1,5 +1,4 @@
 import { Handler, NextFunction, Request, Response } from 'express';
-import { Request as ExpressRequest } from 'express';
 import {
   jwtVerifier,
   tokenVerifier,
@@ -47,7 +46,7 @@ import { resolveHost } from './resolve-host';
  * }
  */
 export type GetCertificate = (
-  req: ExpressRequest
+  req: Request
 ) => ClientCertificate | undefined;
 
 export type AuthOptions = CoreAuthOptions & {
@@ -148,7 +147,7 @@ export const auth = (opts: AuthOptions = {}): Handler => {
       return next(e);
     }
 
-    // Get DPoP verifier instance with the provided options.
+    // Get the token verifier instance with the provided options.
     const requestOptions: RequestLike = {
       headers,
       url,

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -38,6 +38,11 @@ import { resolveHost } from './resolve-host';
  * Return `undefined` when no certificate is present; a certificate-bound token
  * received without one is rejected.
  *
+ * Supplying this resolver also opts the request into mTLS validation: it sets
+ * `mtls.enabled` to `true` by default (see {@Link AuthOptions.getCertificate}).
+ * Set `mtls: { enabled: false }` explicitly to keep mTLS off while still
+ * resolving certificates for your own use.
+ *
  * @example
  * // nginx forwarding URL-encoded PEM in a header:
  * getCertificate: (req) => {
@@ -52,8 +57,10 @@ export type GetCertificate = (
 export type AuthOptions = CoreAuthOptions & {
   /**
    * Resolves the client certificate for mTLS certificate-bound access token
-   * validation (RFC 8705). Required to validate `cnf.x5t#S256` bindings when
-   * running behind a TLS-terminating proxy.
+   * validation (RFC 8705), for use behind a TLS-terminating proxy.
+   *
+   * mTLS is opt-in: supplying this resolver enables it (sets `mtls.enabled`
+   * to `true`) unless `mtls.enabled` is set explicitly.
    */
   getCertificate?: GetCertificate;
 };
@@ -114,9 +121,17 @@ declare global {
  *
  */
 export const auth = (opts: AuthOptions = {}): Handler => {
-  const verifyJwt = jwtVerifier(opts);
-  assertValidDPoPOptions(opts.dpop);
-  assertValidMtlsOptions(opts.mtls);
+  // mTLS is opt-in. Supplying `getCertificate` signals intent to use it, so
+  // it enables mTLS by default unless the caller sets `mtls.enabled` explicitly.
+  const mtls: MtlsOptions | undefined =
+    opts.getCertificate && opts.mtls?.enabled === undefined
+      ? { ...opts.mtls, enabled: true }
+      : opts.mtls;
+  const resolvedOpts: AuthOptions = { ...opts, mtls };
+
+  const verifyJwt = jwtVerifier(resolvedOpts);
+  assertValidDPoPOptions(resolvedOpts.dpop);
+  assertValidMtlsOptions(resolvedOpts.mtls);
 
   return async (req: Request, res: Response, next: NextFunction) => {
     const { headers, query, body, method } = req;
@@ -135,16 +150,16 @@ export const auth = (opts: AuthOptions = {}): Handler => {
     }
 
     // Resolve the client certificate for mTLS certificate-bound tokens, if a
-    // resolver was supplied. Errors from the caller's resolver propagate through
-    // the same authRequired handling as other verification failures.
+    // resolver was supplied. A resolver failure does not skip JWT verification:
+    // it just leaves the certificate unresolved. A plain Bearer token still
+    // verifies normally; a certificate-bound token then fails with the same
+    // "certificate required" error verifyMtls already raises when no resolver
+    // is configured at all, going through the usual authRequired handling below.
     let clientCertificate: ClientCertificate | undefined;
     try {
       clientCertificate = opts.getCertificate?.(req);
-    } catch (e) {
-      if (opts.authRequired === false) {
-        return next();
-      }
-      return next(e);
+    } catch {
+      clientCertificate = undefined;
     }
 
     // Get the token verifier instance with the provided options.
@@ -159,7 +174,7 @@ export const auth = (opts: AuthOptions = {}): Handler => {
     };
 
     // Verify both JWT and DPoP token claims.
-    const verifier = tokenVerifier(verifyJwt, opts, requestOptions);
+    const verifier = tokenVerifier(verifyJwt, resolvedOpts, requestOptions);
 
     try {
       req.auth = await verifier.verify();

--- a/packages/express-oauth2-jwt-bearer/src/index.ts
+++ b/packages/express-oauth2-jwt-bearer/src/index.ts
@@ -1,8 +1,10 @@
 import { Handler, NextFunction, Request, Response } from 'express';
+import { Request as ExpressRequest } from 'express';
 import {
   jwtVerifier,
   tokenVerifier,
   assertValidDPoPOptions,
+  assertValidMtlsOptions,
   claimCheck as _claimCheck,
   ClaimCheck,
   claimEquals as _claimEquals,
@@ -15,10 +17,47 @@ import {
   VerifyJwtResult as AuthResult,
   JWTPayload,
   RequestLike,
-  AuthOptions,
-  DPoPOptions
+  AuthOptions as CoreAuthOptions,
+  DPoPOptions,
+  MtlsOptions,
+  ClientCertificate
 } from 'access-token-jwt';
 import { resolveHost } from './resolve-host';
+
+/**
+ * Resolves the client certificate presented on the TLS connection for the
+ * current request, used to validate certificate-bound (mTLS, RFC 8705) access
+ * tokens.
+ *
+ * APIs typically run behind a TLS-terminating proxy (nginx, ALB, Cloudflare,
+ * etc.) that forwards the client certificate in a request header (commonly as
+ * URL-encoded PEM). Because the header name and encoding vary by deployment,
+ * you supply this function to extract the certificate from wherever your proxy
+ * places it, returning the PEM text or DER bytes. For a process terminating TLS
+ * directly, return `req.socket.getPeerCertificate().raw`.
+ *
+ * Return `undefined` when no certificate is present; a certificate-bound token
+ * received without one is rejected.
+ *
+ * @example
+ * // nginx forwarding URL-encoded PEM in a header:
+ * getCertificate: (req) => {
+ *   const pem = req.headers['client-certificate'];
+ *   return typeof pem === 'string' ? decodeURIComponent(pem) : undefined;
+ * }
+ */
+export type GetCertificate = (
+  req: ExpressRequest
+) => ClientCertificate | undefined;
+
+export type AuthOptions = CoreAuthOptions & {
+  /**
+   * Resolves the client certificate for mTLS certificate-bound access token
+   * validation (RFC 8705). Required to validate `cnf.x5t#S256` bindings when
+   * running behind a TLS-terminating proxy.
+   */
+  getCertificate?: GetCertificate;
+};
 
 declare global {
   namespace Express {
@@ -78,6 +117,7 @@ declare global {
 export const auth = (opts: AuthOptions = {}): Handler => {
   const verifyJwt = jwtVerifier(opts);
   assertValidDPoPOptions(opts.dpop);
+  assertValidMtlsOptions(opts.mtls);
 
   return async (req: Request, res: Response, next: NextFunction) => {
     const { headers, query, body, method } = req;
@@ -95,6 +135,19 @@ export const auth = (opts: AuthOptions = {}): Handler => {
       return next(e);
     }
 
+    // Resolve the client certificate for mTLS certificate-bound tokens, if a
+    // resolver was supplied. Errors from the caller's resolver propagate through
+    // the same authRequired handling as other verification failures.
+    let clientCertificate: ClientCertificate | undefined;
+    try {
+      clientCertificate = opts.getCertificate?.(req);
+    } catch (e) {
+      if (opts.authRequired === false) {
+        return next();
+      }
+      return next(e);
+    }
+
     // Get DPoP verifier instance with the provided options.
     const requestOptions: RequestLike = {
       headers,
@@ -103,6 +156,7 @@ export const auth = (opts: AuthOptions = {}): Handler => {
       query,
       body,
       isUrlEncoded: !!req.is('urlencoded'),
+      clientCertificate,
     };
 
     // Verify both JWT and DPoP token claims.
@@ -209,7 +263,13 @@ export const requiredScopes: RequiredScopes<Handler> = (...args) =>
 export const scopeIncludesAny: RequiredScopes<Handler> = (...args) =>
   toHandler(_scopeIncludesAny(...args));
 
-export { AuthResult, JWTPayload, AuthOptions, DPoPOptions };
+export {
+  AuthResult,
+  JWTPayload,
+  DPoPOptions,
+  MtlsOptions,
+  ClientCertificate,
+};
 export {
   FunctionValidator,
   Validator,

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -612,6 +612,33 @@ describe('index', () => {
         .digest('base64url');
     });
 
+    it('passes through a cert-bound token unvalidated when getCertificate is not configured (mTLS is opt-in)', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({});
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('does not validate mTLS when explicitly disabled, even with getCertificate configured', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': 'not-the-real-thumbprint' } },
+      });
+      const baseUrl = await setup({
+        mtls: { enabled: false },
+        getCertificate: () => certPem,
+      });
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
     it('accepts a cert-bound token when the presented certificate matches', async () => {
       const jwt = await createJwt({
         payload: { cnf: { 'x5t#S256': certThumbprint } },
@@ -717,7 +744,27 @@ describe('index', () => {
       expect(response.statusCode).toBe(200);
     });
 
-    it('propagates an error thrown by getCertificate', async () => {
+    it('does not skip JWT verification for a plain bearer token when getCertificate throws', async () => {
+      // getCertificate failing must not short-circuit verification for tokens
+      // that never needed a certificate in the first place.
+      const jwt = await createJwt({ payload: { foo: 'bar' } });
+      const baseUrl = await setup({
+        getCertificate: () => {
+          throw new InvalidRequestError('bad proxy header');
+        },
+      });
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+      expect((response.body as any).payload.foo).toBe('bar');
+    });
+
+    it('rejects a cert-bound token for a missing certificate when getCertificate throws', async () => {
+      // The resolver's own error is not propagated: the certificate is simply
+      // treated as unresolved, and the cert-bound token is rejected the same
+      // way it would be with no getCertificate configured at all.
       const jwt = await createJwt({
         payload: { cnf: { 'x5t#S256': certThumbprint } },
       });
@@ -732,7 +779,7 @@ describe('index', () => {
         }),
         400,
         'invalid_request',
-        'bad proxy header'
+        'A client certificate is required for this certificate-bound access token'
       );
     });
 

--- a/packages/express-oauth2-jwt-bearer/test/index.test.ts
+++ b/packages/express-oauth2-jwt-bearer/test/index.test.ts
@@ -576,4 +576,183 @@ describe('index', () => {
 
   });
 
+  describe('mTLS (RFC 8705) certificate-bound tokens', () => {
+    const { execFileSync } = require('child_process');
+    const { createHash } = require('crypto');
+    const { tmpdir } = require('os');
+    const { join } = require('path');
+    const fs = require('fs');
+
+    let certPem: string;
+    let certThumbprint: string;
+
+    beforeAll(() => {
+      const dir = join(tmpdir(), `mtls-express-${process.pid}`);
+      fs.mkdirSync(dir, { recursive: true });
+      try {
+        const key = join(dir, 'client.key');
+        const crt = join(dir, 'client.crt');
+        execFileSync('openssl', [
+          'req', '-x509', '-newkey', 'rsa:2048',
+          '-keyout', key, '-out', crt,
+          '-days', '1', '-nodes', '-subj', '/CN=client',
+        ]);
+        certPem = fs.readFileSync(crt, 'utf8');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+      const PEM_RE =
+        /-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\s]+?)-----END CERTIFICATE-----/;
+      const der = Buffer.from(
+        certPem.match(PEM_RE)![1].replace(/\s+/g, ''),
+        'base64'
+      );
+      certThumbprint = createHash('sha256')
+        .update(der)
+        .digest('base64url');
+    });
+
+    it('accepts a cert-bound token when the presented certificate matches', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({
+        getCertificate: () => certPem,
+      });
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+      expect((response.body as any).payload.cnf['x5t#S256']).toBe(
+        certThumbprint
+      );
+    });
+
+    it('rejects a cert-bound token when the certificate does not match', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': 'not-the-real-thumbprint' } },
+      });
+      const baseUrl = await setup({
+        getCertificate: () => certPem,
+      });
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { authorization: `Bearer ${jwt}` },
+          responseType: 'json',
+        }),
+        401,
+        'invalid_token'
+      );
+    });
+
+    it('rejects a cert-bound token when no certificate is presented', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({
+        getCertificate: () => undefined,
+      });
+      // A cert-bound token received without a presented certificate is a
+      // malformed request (InvalidRequestError -> 400 invalid_request), not an
+      // invalid token.
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { authorization: `Bearer ${jwt}` },
+          responseType: 'json',
+        }),
+        400,
+        'invalid_request'
+      );
+    });
+
+    it('accepts a plain bearer token unaffected when mTLS is not triggered', async () => {
+      const jwt = await createJwt({ payload: { foo: 'bar' } });
+      const baseUrl = await setup({
+        getCertificate: () => certPem,
+      });
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+      expect((response.body as any).payload.foo).toBe('bar');
+    });
+
+    it('rejects a plain bearer token when mTLS is required', async () => {
+      const jwt = await createJwt({ payload: { foo: 'bar' } });
+      const baseUrl = await setup({
+        mtls: { required: true },
+        getCertificate: () => certPem,
+      });
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { authorization: `Bearer ${jwt}` },
+          responseType: 'json',
+        }),
+        401,
+        'invalid_token'
+      );
+    });
+
+    it('resolves the certificate from a proxy header via getCertificate', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({
+        getCertificate: (req) => {
+          const header = req.headers['client-certificate'];
+          return typeof header === 'string'
+            ? decodeURIComponent(header)
+            : undefined;
+        },
+      });
+      const response = await got(baseUrl, {
+        headers: {
+          authorization: `Bearer ${jwt}`,
+          'client-certificate': encodeURIComponent(certPem),
+        },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('propagates an error thrown by getCertificate', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({
+        getCertificate: () => {
+          throw new InvalidRequestError('bad proxy header');
+        },
+      });
+      await expectFailsWith(
+        got(baseUrl, {
+          headers: { authorization: `Bearer ${jwt}` },
+        }),
+        400,
+        'invalid_request',
+        'bad proxy header'
+      );
+    });
+
+    it('ignores an error thrown by getCertificate when authRequired is false', async () => {
+      const jwt = await createJwt({
+        payload: { cnf: { 'x5t#S256': certThumbprint } },
+      });
+      const baseUrl = await setup({
+        authRequired: false,
+        getCertificate: () => {
+          throw new Error('boom');
+        },
+      });
+      const response = await got(baseUrl, {
+        headers: { authorization: `Bearer ${jwt}` },
+        responseType: 'json',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeFalsy();
+    });
+  });
+
 });


### PR DESCRIPTION
## Description

Adds support for **mTLS certificate-bound access tokens** ([RFC 8705](https://www.rfc-editor.org/rfc/rfc8705)) to the resource-server SDK.

When a client authenticates to the authorization server with a TLS client certificate, the issued access token carries a `cnf.x5t#S256` claim: the base64url-encoded SHA-256 thumbprint of that certificate. This change validates, on every request, that the certificate presented on the TLS connection matches the thumbprint in the token, so a stolen bearer token cannot be replayed from a different client.

Because APIs typically run behind a TLS-terminating proxy (nginx, ALB, Cloudflare, etc.), the SDK cannot read the TLS socket directly. The caller supplies a `getCertificate(req)` function that returns the presented certificate (PEM or DER), which the SDK then verifies.

## What's included

- **`access-token-jwt`**
  - New `mtls-verifier.ts`: thumbprint calculation (`base64url(SHA-256(DER))`), `cnf` confirmation-claim validation, and `verifyMtls`.
  - `token-verifier.ts`: new `mtls: { enabled, required }` option, with startup validation. DPoP and mTLS are mutually exclusive per token (a token carries at most one confirmation method); DPoP-bound tokens continue through the DPoP path.
- **`express-oauth2-jwt-bearer`**
  - New `getCertificate` option on `auth()`, wired into the verification flow and respecting `authRequired`.
- **Docs**: "mTLS Certificate-Bound Tokens" section in `EXAMPLES.md` (getCertificate, proxy/nginx deployment, the three modes, and a behavior matrix) plus a README pointer.

## Behavior matrix

| `enabled` | `required` | Behavior |
| --- | --- | --- |
| `true` | `false` (default) | Validate binding when `cnf.x5t#S256` is present; non-bound tokens pass through. |
| `true` | `true` | Every token must be certificate-bound. Missing cert → `400 invalid_request`; mismatch or unbound → `401 invalid_token`. |
| `false` | `false` | `cnf.x5t#S256` ignored; tokens accepted as plain Bearer JWTs. |
| `false` | `true` | Invalid — throws on startup. |

## Testing

- New unit tests for the verifier and the middleware wiring; **100% coverage** on new code, full suite green (537 tests).
- Verified end-to-end against an Auth0 tenant with a real certificate-bound token (custom domain + mTLS endpoint aliases, nginx terminating TLS) across all three modes; the non-bound-token case (`required` rejects, `optional` accepts) was additionally verified with a locally-minted token.

## Backwards compatibility

Fully backwards compatible. mTLS validation only triggers when a token carries `cnf.x5t#S256` (default `required: false`), so existing bearer-token deployments are unaffected. `getCertificate` is optional.
