### PR TITLE
fix: allow extra cnf members alongside jkt for DPoP validation

### DIFF
--- a/packages/access-token-jwt/src/dpop-verifier.ts
+++ b/packages/access-token-jwt/src/dpop-verifier.ts
@@ -17,6 +17,7 @@ import {
 
 export interface ConfirmationClaims {
   jkt: string;
+  [key: string]: unknown;
 }
 interface DPoPJWTPayload extends JWTPayload {
   cnf?: ConfirmationClaims;
@@ -215,12 +216,6 @@ function assertDPoPRequest(
 
     if (!isJsonObject(cnf)) {
       throw new InvalidTokenError('Invalid "cnf" confirmation claim structure');
-    }
-
-    if (Object.keys(cnf).length > 1) {
-      throw new InvalidTokenError(
-        'Multiple confirmation claims are not supported'
-      );
     }
 
     if (!('jkt' in cnf)) {

--- a/packages/access-token-jwt/test/dpop-verifier.test.ts
+++ b/packages/access-token-jwt/test/dpop-verifier.test.ts
@@ -720,6 +720,17 @@ describe('verifyDPoP', () => {
     await expect(verifyDPoP(createOptions())).resolves.toBeUndefined();
   });
 
+  it('passes when cnf carries jkt plus additional extension members', async () => {
+    headers.dpop = await createProof();
+    await expect(
+      verifyDPoP(
+        createOptions({
+          accessTokenClaims: { cnf: { jkt: thumbprint, 'kc-jkt-type': 'DPoP' } },
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+
   it('fails when headers are invalid (delegates to assertDPoPRequest)', async () => {
     // No authorization or dpop -> assertDPoPRequest should throw
     const opts = createOptions({ headers: {} as any });

--- a/packages/access-token-jwt/test/dpop-verifier.test.ts
+++ b/packages/access-token-jwt/test/dpop-verifier.test.ts
@@ -555,13 +555,8 @@ describe('assertDPoPRequest', () => {
     );
   });
 
-  it('fails when cnf contains multiple keys', () => {
-    expectFail(
-      baseHeaders(),
-      { cnf: { jkt: 'thumb', extra: 'x' } },
-      'Multiple confirmation claims are not supported',
-      InvalidTokenError
-    );
+  it('passes when cnf contains jkt and additional extension members', () => {
+    expectPass(baseHeaders(), { cnf: { jkt: 'abc', 'kc-jkt-type': 'DPoP' } });
   });
 
   it('fails when cnf.jkt is missing (undefined)', () => {


### PR DESCRIPTION
## Summary

- Removes the `Object.keys(cnf).length > 1` guard in `dpop-verifier.ts` that incorrectly rejected tokens where the `cnf` claim contained additional members alongside `jkt`
- Widens the `ConfirmationClaims` interface to allow extension members per RFC 7800
- Flips the existing test for this case to assert the correct passing behaviour

## References

- [RFC 7800 §3.1](https://datatracker.ietf.org/doc/html/rfc7800#section-3.1) — _"in the absence of such requirements, all confirmation members that are not understood by implementations MUST be ignored"_
- [RFC 9449 §6](https://datatracker.ietf.org/doc/html/rfc9449#section-6) — requires `cnf.jkt` to be present and match the DPoP proof public key thumbprint; does not restrict `cnf` to a single member

## Related

Fixes #254

## Design note: other confirmation methods (issue #254, point 4)

Ignoring additional `cnf` members is intentional, not an oversight.

This SDK implements a single confirmation method — DPoP via `cnf.jkt` (RFC 9449) — which remains fully validated (present, string, non-empty, and thumbprint-matched against the DPoP proof key). It does not implement
the `jwk` / `jwe` / `jku` (RFC 7800 §3.1) or `x5t#S256` (RFC 8705, mTLS) proof-of-possession methods.

RFC 7800 §3.1's "at most one of jwk/jwe/jku" rule constrains an implementation that processes those key representations; we do not. Per the same section, confirmation members an implementation does not understand MUST be ignored. Accordingly, extra members (e.g. Keycloak's `kc-jkt-type`, or an `x5t#S256` cert binding) are ignored and `jkt` remains the only enforced binding — no second key is honored.

We deliberately do not add a denylist of competing PoP methods: it would not improve conformance (those methods aren't validated here regardless) and would re-introduce the over-strict rejection this PR fixes as new confirmation members get registered.

Note this is not client-exploitable: `cnf` originates from a signature-verified access token, so only a misbehaving AS could emit these shapes, and `jkt` is enforced in every case.

## Test plan

- [x] Existing test suite passes with 100% coverage
- [x] Test asserts `cnf` with `jkt` + additional extension members (e.g. Keycloak's `kc-jkt-type`) is accepted
