### PR TITLE
chore: add npm dependabot entries for all workspace packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
       codeql:
         patterns:
           - 'github/codeql-action/*'
+
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/packages/access-token-jwt'
+      - '/packages/oauth2-bearer'
+      - '/packages/express-oauth2-jwt-bearer'
+      - '/packages/examples'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
## Summary

Dependabot was only configured for GitHub Actions. This adds `npm` entries covering all four workspace packages so that dependencies are kept up to date automatically.

Dependabot does not auto-discover `package.json` files in a monorepo, so each workspace directory is listed explicitly using the `directories` shorthand.