### PR TITLE
docs: recommend @auth0/auth0-express-api for Auth0 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Monorepo for `oauth2-jwt-bearer`. Contains the following packages:
 | [access-token-jwt](./packages/access-token-jwt)                   |     ✘     | Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12) |
 | [express-oauth2-jwt-bearer](./packages/express-oauth2-jwt-bearer) |     ✔     | Authentication middleware for Express.js that validates JWT Bearer Access Tokens                                                                                 |
 
-> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out the [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) SDK, currently in beta.
-
 ## Feedback
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Monorepo for `oauth2-jwt-bearer`. Contains the following packages:
 | [access-token-jwt](./packages/access-token-jwt)                   |     ✘     | Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12) |
 | [express-oauth2-jwt-bearer](./packages/express-oauth2-jwt-bearer) |     ✔     | Authentication middleware for Express.js that validates JWT Bearer Access Tokens                                                                                 |
 
+> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out the [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) SDK, currently in beta.
+
 ## Feedback
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Monorepo for `oauth2-jwt-bearer`. Contains the following packages:
 | [access-token-jwt](./packages/access-token-jwt)                   |     ✘     | Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12) |
 | [express-oauth2-jwt-bearer](./packages/express-oauth2-jwt-bearer) |     ✔     | Authentication middleware for Express.js that validates JWT Bearer Access Tokens                                                                                 |
 
+> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out our framework-specific API SDKs, currently in beta: [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) for Express and [`@auth0/auth0-fastify-api`](https://github.com/auth0/auth0-fastify) for Fastify.
+
 ## Feedback
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Monorepo for `oauth2-jwt-bearer`. Contains the following packages:
 | [access-token-jwt](./packages/access-token-jwt)                   |     ✘     | Verfies and decodes Access Token JWTs loosley following [draft-ietf-oauth-access-token-jwt-12](https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt-12) |
 | [express-oauth2-jwt-bearer](./packages/express-oauth2-jwt-bearer) |     ✔     | Authentication middleware for Express.js that validates JWT Bearer Access Tokens                                                                                 |
 
-> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out our framework-specific API SDKs, currently in beta: [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) for Express and [`@auth0/auth0-fastify-api`](https://github.com/auth0/auth0-fastify) for Fastify.
+> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out our framework-specific API SDKs: [`@auth0/auth0-fastify-api`](https://github.com/auth0/auth0-fastify) for Fastify and [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) (currently in beta) for Express.
 
 ## Feedback
 

--- a/packages/express-oauth2-jwt-bearer/README.md
+++ b/packages/express-oauth2-jwt-bearer/README.md
@@ -8,6 +8,8 @@
 
 📚 [Documentation](#documentation) - 🚀 [Getting Started](#getting-started) - 💻 [API Reference](#api-reference) - 💬 [Feedback](#feedback)
 
+> 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out the [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) SDK, currently in beta.
+
 ## Documentation
 
 - [Docs Site](https://auth0.com/docs) - explore our Docs site and learn more about Auth0.


### PR DESCRIPTION
## 📋 Changes

Adds callouts recommending Auth0 users try Auth0's framework-specific API SDKs.

- **`packages/express-oauth2-jwt-bearer/README.md`** (npm landing page) — Express-specific note, just after the nav line before `## Documentation`:

  ```markdown
  > 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out the [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) SDK, currently in beta.
  ```

- **`README.md`** (monorepo root) — framework-neutral note listing both API SDKs, since the root covers framework-agnostic packages:

  ```markdown
  > 💡 **Using Auth0?** If you want Auth0-specific features, we recommend trying out our framework-specific API SDKs: [`@auth0/auth0-fastify-api`](https://github.com/auth0/auth0-fastify) for Fastify and [`@auth0/auth0-express-api`](https://github.com/auth0/auth0-express) (currently in beta) for Express.
  ```

## 🎯 Testing

Docs-only change; no code affected.